### PR TITLE
3 - Fix extract failing to capture stdout values

### DIFF
--- a/test/test_borgapi.py
+++ b/test/test_borgapi.py
@@ -257,15 +257,16 @@ class BorgapiTests(unittest.TestCase):
             "Warning not logged for bad path",
         )
 
-    @unittest.skip(
-        "BUG: Captured output uses StringIO which has no buffer like sys.stdout does"
-    )
     def test_extract_stdout(self):
         """Capture Extracted File"""
         api = self._init_and_create(self.repo, "1", self.data)
 
         out, _ = api.extract(f"{self.repo}::1", self.file_1, stdout=True)
-        self.assertEqual(out, self.file_1_text, "Extracted file text does not match")
+        self.assertEqual(
+            out,
+            bytes(self.file_1_text, "utf-8"),
+            "Extracted file text does not match",
+        )
 
     def test_check(self):
         """Check archive / repository integrity"""

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -1,8 +1,8 @@
 """Test the Options module"""
 import unittest
 
-from borgapi import CommonOptions, ExclusionOptions, OptionsBase
-
+from borgapi import CommonOptions, ExclusionOptions
+from borgapi.options import OptionsBase
 
 class OptionsTests(unittest.TestCase):
     """Tests for the Options Dataclasses"""


### PR DESCRIPTION
When using the stdout option with the extract command, it now captures
the output into a BytesIO buffer. Otherwise information is captured by
StringIO.

Stderr is always a StringIO object.

resolves #3