### PR TITLE
4 - Fix arg generator not splitting lists correctly

### DIFF
--- a/borgapi/options.py
+++ b/borgapi/options.py
@@ -75,6 +75,13 @@ class OptionsBase:
             defaults.add(field.name)
         return defaults
 
+    @staticmethod
+    def _is_list(type_):
+        try:
+            return issubclass(type_, list)
+        except TypeError:
+            return issubclass(type_.__origin__, list)
+
     def parse(self) -> List[Optional[Union[str, int]]]:
         """Turn options into list for argv
 
@@ -90,11 +97,13 @@ class OptionsBase:
                 if value.type is bool:
                     if attr is not value.default:
                         args.append(flag)
-                elif value.type is list:
+                elif value.type is str or value.type is int:
+                    args.extend([flag, attr])
+                elif self._is_list(value.type):
                     for val in attr:
                         args.extend([flag, val])
                 else:
-                    args.extend([flag, attr])
+                    raise TypeError(f'Unrecognized flag type for "{key}": {value.type}')
         return args
 
 

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -33,7 +33,6 @@ class OptionsTests(unittest.TestCase):
             "Number of Exclusion Options does not match expected number",
         )
 
-    @unittest.skip("BUG: Arg list generator not splitting list vals correctly")
     def test_parse(self):
         """Parsing produces formatted args list from class instance"""
         expected_args = ["--warning", "--progress", "--log-json"]


### PR DESCRIPTION
List args were being added as the list item instead of multiple times.
This was because of a bad type check where the hints were `typing.List`
instead of `list`. Check is a bit more expensive now, so the
str / int check was moved above it and made explicit instead of the
default, if nothing matches a TypeError is raised. Only types accepted
for the options are bool, int, list, and str. If any new ones are added
this check will need to be updated (obviously).

resolves #4