### PR TITLE
12 - Fix Export Tar to stdout

### DIFF
--- a/borgapi/borgapi.py
+++ b/borgapi/borgapi.py
@@ -682,7 +682,7 @@ class BorgAPI:
         arg_list.append(file)
         arg_list.extend(paths)
 
-        return self._run(arg_list, self.archiver.do_export_tar)
+        return self._run(arg_list, self.archiver.do_export_tar, raw_bytes=(file=="-"))
 
     def serve(
         self,

--- a/test/borgapi/test_export_tar.py
+++ b/test/borgapi/test_export_tar.py
@@ -20,3 +20,10 @@ class ExportTarTests(BorgapiTests):
         self.assertFileExists(tar_file, "Tar file not exported")
 
         rmtree(export_dir)
+
+    def test_export_tar_stdout(self):
+        """Export tar file"""
+        api = self._init_and_create(self.repo, "1", self.data)
+
+        out, _ = api.export_tar(f"{self.repo}::1", "-")
+        self.assertTrue(out, "Exported tar contains no bytes exported")


### PR DESCRIPTION
When trying to export a tar to stdout the raw_bytes flag wasn't
being set to true, causing it to try to write to the StringIO buffer
which doesn't exist. With the flag set propperly now, it's able to
retrieve the bytes.

resolves #12