### PR TITLE
Fix Mount Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ pip install borgapi
 ```
 
 Requires:
-* `borgbackup`: 1.1.16
+* `borgbackup`: 1.1.17
 * `python-dotenv`: 0.17.1
 
-Supports Python 3.6 and above.
+Supports Python 3.6 to 3.10
 
 ## Usage
 ```python

--- a/borgapi/options.py
+++ b/borgapi/options.py
@@ -696,7 +696,7 @@ class MountOptional(OptionsBase):
     :type o: str
     """
 
-    foreground: bool = False
+    foreground: bool = True
     o: str = None
 
     # pylint: disable=useless-super-delegation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-borgbackup==1.1.16
+borgbackup[fuse]==1.1.17
 python-dotenv==0.17.1

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="borgapi",
-    version="0.5.0",
+    version="0.5.1",
     author="Sean Slater",
     author_email="seanslater@whatno.io",
     description="Wrapper for borgbackup to easily use in code",
@@ -15,7 +15,7 @@ setuptools.setup(
     url="https://github.com/spslater/borgapi",
     license="MIT License",
     packages=setuptools.find_packages(),
-    install_requires=["borgbackup==1.1.16", "python-dotenv>=0.17.1"],
+    install_requires=["borgbackup[fuse]==1.1.17", "python-dotenv>=0.17.1"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",
@@ -23,9 +23,11 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: MIT License",
         "Topic :: Utilities",
+        "Topic :: System :: Archiving :: Backup",
     ],
     keywords="borgbackup backup api",
     python_requires=">=3.6",

--- a/test/borgapi/test_mount.py
+++ b/test/borgapi/test_mount.py
@@ -2,6 +2,7 @@
 from os import getenv
 from os.path import join
 from shutil import rmtree
+from time import sleep
 
 from .test_borgapi import BorgapiTests
 
@@ -24,19 +25,24 @@ class MountTests(BorgapiTests):
         self._make_clean(self.mountpoint)
 
     def tearDown(self):
-        rmtree(self.mountpoint)
+        if not getenv("BORGAPI_TEST_KEEP_TEMP"):
+            rmtree(self.mountpoint)
         super().tearDown()
 
     def test_repository(self):
         """Mount and unmount a repository"""
-        self.api.mount(self.repo, self.mountpoint)
+        output = self.api.mount(self.repo, self.mountpoint)
+        sleep(5)
+        self.assertTrue(output["pid"] != 0)
         self.assertFileExists(self.repo_file)
         self.api.umount(self.mountpoint)
         self.assertFileNotExists(self.repo_file)
 
     def test_archive(self):
         """Mount and unmount a archive"""
-        self.api.mount(self.archive, self.mountpoint)
+        output = self.api.mount(self.archive, self.mountpoint)
+        sleep(5)
+        self.assertTrue(output["pid"] != 0)
         self.assertFileExists(self.archive_file)
         self.api.umount(self.mountpoint)
         self.assertFileNotExists(self.archive_file)


### PR DESCRIPTION
Using mount would cause the script to exit when `borg` daemonized
during the mount call. Now create a new fork that does the mount
operation. May need to wait a second or two after mounting to make
sure it actually does mount.

resolves #15