### PR TITLE
Enhancement 18 - Compact command support

### DIFF
--- a/borgapi/borgapi.py
+++ b/borgapi/borgapi.py
@@ -19,6 +19,7 @@ from .options import (
     ArchivePattern,
     CommandOptions,
     CommonOptions,
+    CompactOptional
     ExclusionInput,
     ExclusionOptions,
     ExclusionOutput,
@@ -585,6 +586,37 @@ class BorgAPI:
             result_list.append(("stats", output["stats"]))
         elif prune_options.stats and common_options.log_json:
             result_list.append(("stats", self._loads_json_lines(output["stats"])))
+
+        return self._build_result(*result_list)
+
+    def compact(self, repository: str, **options: Options) -> Output:
+        """Compact frees repository space by compacting segments.
+
+        :param repository: repository to compact
+        :type repository: str
+        :param **options: optional arguments specific to `compact` as well as archive and
+            common options; defaults to {}
+        :type **options: Options
+        :return: Stdout of command, None if no output created,
+            dict if json flag used, str otherwise
+        :rtype: Output
+        """
+        common_options = self._get_option(options, CommonOptions)
+        compact_options = self.optionals.get("compact", options)
+
+        arg_list = []
+        arg_list.extend(common_options.parse())
+        arg_list.append("compact")
+        arg_list.extend(compact_options.parse())
+        arg_list.append(repository)
+
+        output = self._run(arg_list, self.archiver.do_compact)
+
+        result_list = []
+        if common_options.log_json:
+            result_list.append(("compact", self._loads_json_lines(output["stderr"])))
+        else:
+            result_list.append(("compact", output["stderr"]))
 
         return self._build_result(*result_list)
 

--- a/borgapi/borgapi.py
+++ b/borgapi/borgapi.py
@@ -7,10 +7,11 @@ from io import BytesIO, StringIO, TextIOWrapper
 from json import decoder, loads
 from typing import Callable, List, Optional, Tuple, Union
 
-import borg.archive
+# import borg.archive
 import borg.archiver
-import borg.helpers
-import borg.repository
+# import borg.helpers
+# import borg.repository
+from borg.logger import JsonFormatter
 from dotenv import dotenv_values, load_dotenv
 
 from .options import (
@@ -19,7 +20,7 @@ from .options import (
     ArchivePattern,
     CommandOptions,
     CommonOptions,
-    CompactOptional
+    CompactOptional,
     ExclusionInput,
     ExclusionOptions,
     ExclusionOutput,
@@ -33,6 +34,8 @@ Json = Union[list, dict]
 Output = Union[str, Json, None]
 Options = Union[bool, str, int]
 
+LOG_LVL = "warning"
+
 
 class OutputCapture:
     """Capture stdout and stderr by redirecting to inmemory streams
@@ -41,14 +44,17 @@ class OutputCapture:
     :type raw: bool
     """
 
-    def __init__(self, raw: bool = False):
+    def __init__(self, raw: bool = False, log_json: bool = False, log_level: str = LOG_LVL):
         self.raw = raw
+        fmt = "%(message)s"
+        self.formatter = JsonFormatter(fmt) if log_json else logging.Formatter(fmt)
+        self.level = log_level.upper()
         self._init_stdout(raw)
         self._init_stderr()
 
-        self.formatter = logging.Formatter("%(message)s")
         self._init_list_capture()
         self._init_stats_capture()
+        self._init_repo_capture()
 
     def _init_stdout(self, raw: bool):
         self.stdout = TextIOWrapper(BytesIO()) if raw else StringIO()
@@ -63,6 +69,7 @@ class OutputCapture:
     def _init_list_capture(self):
         self.list_handler = logging.StreamHandler(StringIO())
         self.list_handler.setFormatter(self.formatter)
+        # self.list_handler.setLevel(self.level)
         self.list_handler.setLevel("INFO")
 
         self.list_logger = logging.getLogger("borg.output.list")
@@ -71,10 +78,19 @@ class OutputCapture:
     def _init_stats_capture(self):
         self.stats_handler = logging.StreamHandler(StringIO())
         self.stats_handler.setFormatter(self.formatter)
+        # self.stats_handler.setLevel(self.level)
         self.stats_handler.setLevel("INFO")
 
         self.stats_logger = logging.getLogger("borg.output.stats")
         self.stats_logger.addHandler(self.stats_handler)
+
+    def _init_repo_capture(self):
+        self.repo_handler = logging.StreamHandler(StringIO())
+        self.repo_handler.setFormatter(self.formatter)
+        self.repo_handler.setLevel(self.level)
+
+        self.repo_logger = logging.getLogger("borg.repository")
+        self.repo_logger.addHandler(self.repo_handler)
 
     # pylint: disable=no-member
     def getvalues(self) -> Union[str, bytes]:
@@ -92,12 +108,14 @@ class OutputCapture:
 
         list_value = self.list_handler.stream.getvalue()
         stats_value = self.stats_handler.stream.getvalue()
+        repo_value = self.repo_handler.stream.getvalue()
 
         return {
             "stdout": stdout_value,
             "stderr": stderr_value,
             "list": list_value,
             "stats": stats_value,
+            "repo": repo_value,
         }
 
     def close(self):
@@ -123,7 +141,7 @@ class BorgAPI:
         self,
         defaults: dict = None,
         options: dict = None,
-        log_level: str = "info",
+        log_level: str = LOG_LVL,
         log_json: bool = False,
     ):
         self.options = options or {}
@@ -131,8 +149,9 @@ class BorgAPI:
         self.archiver = borg.archiver.Archiver()
         self._previous_dotenv = []
         self._setup_logging(log_level, log_json)
+        self.log_level = log_level
 
-    def _setup_logging(self, log_level: str = "info", log_json: bool = False):
+    def _setup_logging(self, log_level: str = LOG_LVL, log_json: bool = False):
         self.logger_setup = False
         self.archiver.log_json = log_json or self.options.get("log_json", False)
         borg.archiver.setup_logging(level=log_level, is_serve=False, json=log_json)
@@ -171,6 +190,7 @@ class BorgAPI:
         arg_list: List,
         func: Callable,
         raw_bytes: bool = False,
+        log_level: str = LOG_LVL
     ) -> dict:
         self._logger.debug("%s: %s", func.__name__, arg_list)
         arg_list.insert(0, "borgapi")
@@ -181,7 +201,7 @@ class BorgAPI:
         log_json = getattr(args, "log_json", prev_json)
         self.archiver.log_json = log_json
 
-        capture = OutputCapture(raw_bytes)
+        capture = OutputCapture(raw_bytes, log_json, log_level)
         try:
             func(args)
         except Exception as e:
@@ -203,6 +223,33 @@ class BorgAPI:
     def _get_option_list(self, value: dict, options_class: OptionsBase) -> List:
         option = self._get_option(value, options_class)
         return option.parse()
+
+    def _get_log_level(self, options: dict) -> str:
+        if options.get("critical", False):
+            return "critical"
+        if options.get("error", False):
+            return "error"
+        if options.get("warning", False):
+            return "warning"
+        if options.get("info", False) or options.get("verbose", False):
+            return "info"
+        if options.get("debug", False):
+            return "debug"
+
+        if self.options.get("critical", False):
+            return "critical"
+        if self.options.get("error", False):
+            return "error"
+        if self.options.get("warning", False):
+            return "warning"
+        if self.options.get("info", False) or self.options.get("verbose", False):
+            return "info"
+        if self.options.get("debug", False):
+            return "debug"
+
+        return self.log_level
+
+
 
     def set_environ(
         self,
@@ -282,7 +329,8 @@ class BorgAPI:
         arg_list.extend(self.optionals.to_list("init", options))
         arg_list.append(repository)
 
-        return self._run(arg_list, self.archiver.do_init)
+        lvl = self._get_log_level(options)
+        return self._run(arg_list, self.archiver.do_init, log_level=lvl)
 
     def create(
         self,
@@ -317,7 +365,8 @@ class BorgAPI:
         arg_list.append(archive)
         arg_list.extend(paths)
 
-        output = self._run(arg_list, self.archiver.do_create)
+        lvl = self._get_log_level(options)
+        output = self._run(arg_list, self.archiver.do_create, log_level=lvl)
 
         result_list = []
         if create_options.stats and not create_options.json:
@@ -363,7 +412,8 @@ class BorgAPI:
         arg_list.extend(paths)
 
         raw_bytes = options.get("stdout", False)
-        output = self._run(arg_list, self.archiver.do_extract, raw_bytes=raw_bytes)
+        lvl = self._get_log_level(options)
+        output = self._run(arg_list, self.archiver.do_extract, raw_bytes=raw_bytes, log_level=lvl)
 
         result_list = []
         if extract_options.list and not common_options.log_json:
@@ -395,7 +445,8 @@ class BorgAPI:
         arg_list.extend(self._get_option_list(options, ArchiveOutput))
         arg_list.extend(repository_or_archive)
 
-        self._run(arg_list, self.archiver.do_check)
+        lvl = self._get_log_level(options)
+        self._run(arg_list, self.archiver.do_check, log_level=lvl)
         return self._build_result()
 
     def rename(
@@ -423,7 +474,8 @@ class BorgAPI:
         arg_list.append(archive)
         arg_list.append(newname)
 
-        self._run(arg_list, self.archiver.do_rename)
+        lvl = self._get_log_level(options)
+        self._run(arg_list, self.archiver.do_rename, log_level=lvl)
         return self._build_result()
 
     # pylint: disable=redefined-builtin
@@ -458,7 +510,8 @@ class BorgAPI:
         arg_list.append(repository_or_archive)
         arg_list.extend(paths)
 
-        output = self._run(arg_list, self.archiver.do_list)
+        lvl = self._get_log_level(options)
+        output = self._run(arg_list, self.archiver.do_list, log_level=lvl)
 
         result_list = []
         if common_options.log_json or list_options.json or list_options.json_lines:
@@ -502,7 +555,8 @@ class BorgAPI:
         arg_list.append(archive_2)
         arg_list.extend(paths)
 
-        output = self._run(arg_list, self.archiver.do_diff)
+        lvl = self._get_log_level(options)
+        output = self._run(arg_list, self.archiver.do_diff, log_level=lvl)
 
         result_list = []
         if common_options.log_json or diff_options.json_lines:
@@ -542,7 +596,8 @@ class BorgAPI:
         arg_list.append(repository_or_archive)
         arg_list.extend(archives)
 
-        output = self._run(arg_list, self.archiver.do_delete)
+        lvl = self._get_log_level(options)
+        output = self._run(arg_list, self.archiver.do_delete, log_level=lvl)
 
         result_list = []
         if delete_options.stats and common_options.log_json:
@@ -575,7 +630,8 @@ class BorgAPI:
         arg_list.extend(self._get_option_list(options, ArchivePattern))
         arg_list.append(repository)
 
-        output = self._run(arg_list, self.archiver.do_prune)
+        lvl = self._get_log_level(options)
+        output = self._run(arg_list, self.archiver.do_prune, log_level=lvl)
 
         result_list = []
         if prune_options.list and not common_options.log_json:
@@ -610,13 +666,14 @@ class BorgAPI:
         arg_list.extend(compact_options.parse())
         arg_list.append(repository)
 
-        output = self._run(arg_list, self.archiver.do_compact)
+        lvl = self._get_log_level(options)
+        output = self._run(arg_list, self.archiver.do_compact, log_level=lvl)
 
         result_list = []
         if common_options.log_json:
-            result_list.append(("compact", self._loads_json_lines(output["stderr"])))
+            result_list.append(("compact", self._loads_json_lines(output["repo"])))
         else:
-            result_list.append(("compact", output["stderr"]))
+            result_list.append(("compact", output["repo"]))
 
         return self._build_result(*result_list)
 
@@ -642,7 +699,8 @@ class BorgAPI:
         arg_list.extend(self._get_option_list(options, ArchiveOutput))
         arg_list.append(repository_or_archive)
 
-        output = self._run(arg_list, self.archiver.do_info)
+        lvl = self._get_log_level(options)
+        output = self._run(arg_list, self.archiver.do_info, log_level=lvl)
 
         result_list = []
         if info_options.json:
@@ -686,7 +744,8 @@ class BorgAPI:
 
         pid = os.fork()
         if pid == 0: # child process, this one does the actual mount (in the foreground)
-            self._run(arg_list, self.archiver.do_mount)
+            lvl = self._get_log_level(options)
+            self._run(arg_list, self.archiver.do_mount, log_level=lvl)
             return self._build_result()
         return self._build_result(("mount", {"pid": pid, "cid": os.getpid()}))
 
@@ -707,7 +766,8 @@ class BorgAPI:
         arg_list.append("umount")
         arg_list.append(mountpoint)
 
-        self._run(arg_list, self.archiver.do_umount)
+        lvl = self._get_log_level(options)
+        self._run(arg_list, self.archiver.do_umount, log_level=lvl)
         return self._build_result()
 
     def key_change_passphrase(self, repository: str, **options: Options) -> Output:
@@ -727,7 +787,8 @@ class BorgAPI:
         arg_list.extend(["key", "change-passphrase"])
         arg_list.append(repository)
 
-        self._run(arg_list, self.archiver.do_change_passphrase)
+        lvl = self._get_log_level(options)
+        self._run(arg_list, self.archiver.do_change_passphrase, log_level=lvl)
         return self._build_result()
 
     def key_export(
@@ -756,7 +817,8 @@ class BorgAPI:
         arg_list.append(repository)
         arg_list.append(path)
 
-        self._run(arg_list, self.archiver.do_key_export)
+        lvl = self._get_log_level(options)
+        self._run(arg_list, self.archiver.do_key_export, log_level=lvl)
         return self._build_result()
 
     def key_import(
@@ -785,7 +847,8 @@ class BorgAPI:
         arg_list.append(repository)
         arg_list.append(path)
 
-        self._run(arg_list, self.archiver.do_key_import)
+        lvl = self._get_log_level(options)
+        self._run(arg_list, self.archiver.do_key_import, log_level=lvl)
         return self._build_result()
 
     def upgrade(self, repository: str, **options: Options) -> Output:
@@ -806,7 +869,8 @@ class BorgAPI:
         arg_list.extend(self.optionals.to_list("upgrade", options))
         arg_list.append(repository)
 
-        self._run(arg_list, self.archiver.do_upgrade)
+        lvl = self._get_log_level(options)
+        self._run(arg_list, self.archiver.do_upgrade, log_level=lvl)
         return self._build_result()
 
     def export_tar(
@@ -843,10 +907,12 @@ class BorgAPI:
         arg_list.append(file)
         arg_list.extend(paths)
 
+        lvl = self._get_log_level(options)
         output = self._run(
             arg_list,
             self.archiver.do_export_tar,
             raw_bytes=(file == "-"),
+            log_level=lvl,
         )
 
         result_list = []
@@ -869,7 +935,8 @@ class BorgAPI:
         arg_list.append("serve")
         arg_list.extend(self.optionals.to_list("serve", options))
 
-        self._run(arg_list, self.archiver.do_serve)
+        lvl = self._get_log_level(options)
+        self._run(arg_list, self.archiver.do_serve, log_level=lvl)
         return self._build_result()
 
     def config(
@@ -901,9 +968,10 @@ class BorgAPI:
         arg_list.extend(self._get_option_list(options, ExclusionOutput))
         arg_list.append(repository)
 
+        lvl = self._get_log_level(options)
         result_list = []
         if not changes:
-            output = self._run(arg_list, self.archiver.do_config)
+            output = self._run(arg_list, self.archiver.do_config, log_level=lvl)
             if config_options.list:
                 result_list.append(("list", output["stdout"]))
 
@@ -911,10 +979,10 @@ class BorgAPI:
         for change in changes:
             if isinstance(change, tuple):
                 change = arg_list + [change[0], change[1]]
-                self._run(change, self.archiver.do_config)
+                self._run(change, self.archiver.do_config, log_level=lvl)
             else:
                 change = arg_list + [change]
-                output = self._run(change, self.archiver.do_config)
+                output = self._run(change, self.archiver.do_config, log_level=lvl)
                 change_result.append(output["stdout"])
             result_list.append(("changes", change_result))
 
@@ -949,7 +1017,8 @@ class BorgAPI:
         arg_list.append(command)
         arg_list.extend(args)
 
-        self._run(arg_list, self.archiver.do_with_lock)
+        lvl = self._get_log_level(options)
+        self._run(arg_list, self.archiver.do_with_lock, log_level=lvl)
         return self._build_result()
 
     def break_lock(self, repository: str, **options: Options) -> Output:
@@ -969,7 +1038,8 @@ class BorgAPI:
         arg_list.append("break-lock")
         arg_list.append(repository)
 
-        self._run(arg_list, self.archiver.do_break_lock)
+        lvl = self._get_log_level(options)
+        self._run(arg_list, self.archiver.do_break_lock, log_level=lvl)
         return self._build_result()
 
     def benchmark_crud(
@@ -999,7 +1069,8 @@ class BorgAPI:
         arg_list.append(repository)
         arg_list.append(path)
 
-        output = self._run(arg_list, self.archiver.do_benchmark_crud)
+        lvl = self._get_log_level(options)
+        output = self._run(arg_list, self.archiver.do_benchmark_crud, log_level=lvl)
 
         result_list = [("benchmark", output["stdout"])]
         return self._build_result(*result_list)

--- a/borgapi/options.py
+++ b/borgapi/options.py
@@ -671,7 +671,7 @@ class PruneOptional(OptionsBase):
 
 
 @dataclass
-class CompactOptional(OptionBase):
+class CompactOptional(OptionsBase):
     """Compact command options
     
     :param cleanup_commits: cleanup commit-only 17-byte segment files
@@ -869,6 +869,7 @@ class CommandOptions:
         "diff": DiffOptional,
         "delete": DeleteOptional,
         "prune": PruneOptional,
+        "compact": CompactOptional,
         "info": InfoOptional,
         "mount": MountOptional,
         "key_export": KeyExportOptional,

--- a/borgapi/options.py
+++ b/borgapi/options.py
@@ -671,6 +671,24 @@ class PruneOptional(OptionsBase):
 
 
 @dataclass
+class CompactOptional(OptionBase):
+    """Compact command options
+    
+    :param cleanup_commits: cleanup commit-only 17-byte segment files
+    :type cleanup_commits: bool
+    :param threshold: set minimum threshold for saved space in PERCENT (Default: 10)
+    :type threshold: int
+    """
+
+    cleanup_commits: bool = False
+    threshold: int = 10
+
+    # pylint: disable=useless-super-delegation
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+@dataclass
 class InfoOptional(OptionsBase):
     """Info command options
 

--- a/install-virtenv.sh
+++ b/install-virtenv.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+if ! command -v pyenv &> /dev/null; then
+    echo "pyenv not installed" && exit 1
+fi
+
+eval "$(pyenv init -)" >/dev/null 2>&1
+eval "$(pyenv init --path)"
+eval "$(pyenv virtualenv-init -)"
+
+function update() {
+    pyenv activate "$1"
+    python -m pip install --upgrade pip
+    python -m pip install black pylint isort build twine
+    if [ -e "requirements.txt" ]; then
+        python -m pip install -r requirements.txt --upgrade
+    fi
+    pyenv deactivate
+}
+
+## PYTHON 3.8 ##
+if test -n $(pyenv versions | grep "borglatest-3.8"); then
+    pyenv uninstall "borglatest-3.8"
+fi
+pyenv virtualenv "3.8.16"  "borglatest-3.8"
+update "borglatest-3.8"
+
+## PYTHON 3.9 ##
+if test -n $(pyenv versions | grep "borglatest-3.9"); then
+    pyenv uninstall "borglatest-3.9"
+fi
+pyenv virtualenv "3.9.16"  "borglatest-3.9"
+update "borglatest-3.9"
+
+## PYTHON 3.10 ##
+if test -n $(pyenv versions | grep "borglatest-3.10"); then
+    pyenv uninstall "borglatest-3.10"
+fi
+pyenv virtualenv "3.10.10" "borglatest-3.10"
+update "borglatest-3.10"
+
+## PYTHON 3.11 ##
+if test -n $(pyenv versions | grep "borglatest-3.11"); then
+    pyenv uninstall "borglatest-3.11"
+fi
+pyenv virtualenv "3.11.2"  "borglatest-3.11"
+update "borglatest-3.11"
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-borgbackup[fuse]==1.1.17
+borgbackup[llfuse]==1.2.3
 python-dotenv==0.17.1

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+versions=(
+    "borglatest-3.8"
+    "borglatest-3.9"
+    "borglatest-3.10"
+    "borglatest-3.11"
+)
+
+eval "$(pyenv init -)" >/dev/null 2>&1
+eval "$(pyenv init --path)"
+eval "$(pyenv virtualenv-init -)"
+
+echo > "results.log"
+
+for version in "${versions[@]}"; do
+    pyenv activate $version
+    pip install -r requirements.txt 1>&2 2>/dev/null
+    printf "$version: " 1>&2 | tee -a "results.log"
+    if test "$1" = "-v"; then
+        python -m unittest discover -v 2>&1 | tee -a "results.log"
+    else
+        python -m unittest discover 2>&1 | tee -a "results.log"
+    fi
+    pyenv deactivate
+done

--- a/test/borgapi/test_04_extract.py
+++ b/test/borgapi/test_04_extract.py
@@ -49,4 +49,4 @@ class ExtractTests(BorgapiTests):
         """list to json"""
         output = self.api.extract(self.archive, log_json=True, list=True, dry_run=True)
         self._display("extract 2", output)
-        self.assertAnyType(output, str)
+        self.assertAnyType(output, list, dict)

--- a/test/borgapi/test_08_delete.py
+++ b/test/borgapi/test_08_delete.py
@@ -65,4 +65,4 @@ class DeleteTests(BorgapiTests):
         self._create_default()
         output = self.api.delete(self.archive, stats=True, log_json=True)
         self._display("delete 2", output)
-        self.assertType(output, str)
+        self.assertType(output, list, dict)

--- a/test/borgapi/test_11_mount.py
+++ b/test/borgapi/test_11_mount.py
@@ -37,6 +37,7 @@ class MountTests(BorgapiTests):
         self.assertFileExists(self.repo_file)
         self.api.umount(self.mountpoint)
         self.assertFileNotExists(self.repo_file)
+        sleep(3)
 
     def test_02_archive(self):
         """Mount and unmount a archive"""
@@ -46,3 +47,4 @@ class MountTests(BorgapiTests):
         self.assertFileExists(self.archive_file)
         self.api.umount(self.mountpoint)
         self.assertFileNotExists(self.archive_file)
+        sleep(3)

--- a/test/borgapi/test_16_compact.py
+++ b/test/borgapi/test_16_compact.py
@@ -1,0 +1,33 @@
+"""Test deff command"""
+from .test_01_borgapi import BorgapiTests
+
+
+class CompactTests(BorgapiTests):
+    """Compact command tests"""
+
+    def setUp(self):
+        super().setUp()
+        self._create_default()
+        with open(self.file_3, "w") as fp:
+            fp.write(self.file_3_text)
+        self.api.create(f"{self.repo}::2", self.data)
+        self.api.delete(self.archive)
+
+    def test_01_output(self):
+        """Compact string"""
+        output = self.api.compact(self.repo)
+        self._display("compact sting", output)
+        self.assertNone(output)
+
+    def test_02_output_verbose(self):
+        """Compact string"""
+        output = self.api.compact(self.repo, verbose=True)
+        self._display("compact sting verbose", output)
+        self.assertType(output, str)
+
+    def test_03_output_json(self):
+        """Compact json"""
+        output = self.api.compact(self.repo, verbose=True, log_json=True)
+        self._display("compact log json", output)
+        self.assertAnyType(output, dict)
+


### PR DESCRIPTION
Update to v1.2.3 Latest Version of BorgBackup required

* Update to version 1.2.3 of borgbackup 
* Fix an issue where mounting and unmount take a couple seconds
    so the tests were failing. Added a small sleep after the
    command to let the OS take it's time to do that.
* Repository compacting was added in borg v1.2.1, adding support for it
* Update other tests that broke with new changes
