### PR TITLE
Make progress flag useful, add missing commands, add default environment variables, bump versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2025-01-20
+## Added
+- Borg command `recreate` and `import-tar` [#24]
+- Async class! Now you can view output logs while the command is running and not only 
+  when it has completed. This makes the `--progress` flag not useless. [#21]
+- Support for Python version 3.12 and 3.13
+- Add `environ` argument to the `BorgAPI` constructor
+- Load default environmental variables to prevent the api from freezing while waiting for
+  user input. They won't be overriden if they are already set. See README for list of 
+  variables that get set and their defaults. [#20]
+
+### Changed
+- Borg version bumped to 1.4.0
+- Changed the version requirements for `borgbackup` and `python-dotenv` to use compatible
+  release clause (`~=`) instead of a version matching (`==`) clause. This should allow any
+  security patches published to still work while any minor chagnes will need to be verified. 
+- Using `ruff` to lint and format now. Previously used `pylint` to lint and `black` and
+  `isort` to format.
+
+### Removed
+- No longer support Python 3.8 because borgbackup no longer supports that version.
+
 ## [0.6.1] - 2023-03-27
 ### Changed
 - Borg version bumped to 1.2.4

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ pip install borgapi
 ```
 
 Requires:
-* `borgbackup`: 1.2.4
-* `python-dotenv`: 1.0.0
+* `borgbackup`: 1.4.0
+* `python-dotenv`: 1.0.1
 
-Supports Python 3.8 to 3.11
+Supports Python 3.9 to 3.13
 
 ## Usage
 ```python
@@ -23,12 +23,12 @@ import borgapi
 api = borgapi.BorgAPI(defaults={}, options={})
 
 # Initalize new repository
-api.init("/foo/bar", make_parent_dirs=True)
+api.init("foo/bar", make_parent_dirs=True)
 
 # Create backup 
-result = api.create("/foo/bar::backup", "/home", "/mnt/baz", json=True)
+result = api.create("foo/bar::backup", "/home", "/mnt/baz", json=True)
 print(result['archive']["name"]) # backup
-print(result["repository"]["location"]) # /foo/bar
+print(result["repository"]["location"]) # foo/bar
 ```
 
 ### BorgAPI Init arguments
@@ -37,7 +37,8 @@ class BorgAPI(
     defaults: dict = None,
     options: dict = None,
     log_level: str = "warning",
-    log_json: bool = False
+    log_json: bool = False,
+    environ: dict = None,
 )
 ```
 * __defaults__: dictionary that has command names as keys and value that is a dict of
@@ -71,12 +72,35 @@ class BorgAPI(
   level as and keyword argument
 * __log_json__: log lines written by logger are formatted as json lines, passed into the
   logging setup
+* __environ__: dictionary that contains environmental variables that should be set before running
+  any commands. Useful for setting the passphrase or passcommand for the repository or other
+  settings like that. See [Environment Variables](#Setting-Environment-Variables) section for
+  how to set environmental variables after initalization or what the defaults are.
+```python
+{
+  "BORG_CHECK_I_KNOW_WHAT_I_AM_DOING": "YES",
+  "BORG_PASSCOMMAND": "cat ~/.borg/password",
+}
+```
 
 ### Setting Environment Variables
 You are able to manage the environment variables used by borg to be able to use different settings
 for different repositories.
 
-There are 3 ways you can set the variables:
+When initialzing the `BorgAPI` object, you can include a dictionary with the `environ` argument.
+
+The following are the defaults that BorgAPI will always load so that user input does not hold up
+the app from progressing.
+```ini
+BORG_EXIT_CODES=modern,
+BORG_PASSPHRASE="",
+BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK=no,
+BORG_RELOCATED_REPO_ACCESS_IS_OK=no,
+BORG_CHECK_I_KNOW_WHAT_I_AM_DOING=NO,
+BORG_DELETE_I_KNOW_WHAT_I_AM_DOING=NO,
+```
+
+There are 3 ways you can set the variables after initialization:
 1. `filename`: Path to a file that contains the variables and their values. See the
    [python-dotenv README](https://github.com/theskumar/python-dotenv/blob/master/README.md#file-format)
    for more information.
@@ -98,14 +122,6 @@ will be used, which is searching for a ".env" file somewhere above in the curren
 
 [Environment Variables](https://borgbackup.readthedocs.io/en/stable/usage/general.html#environment-variables)
 used by `borgbackup`.
-
-#### IMPORTANT
-For commands that borg requires a confirmation on if no environment variable is given, the api will
-become stuck as it waits for a `yes` or `no` answer.
-* BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK
-* BORG_RELOCATED_REPO_ACCESS_IS_OK
-* BORG_CHECK_I_KNOW_WHAT_I_AM_DOING
-* BORG_DELETE_I_KNOW_WHAT_I_AM_DOING
 
 ### Removing Environment Variables
 If you want to unset a variable so it doesn't get used for another command you can use the
@@ -133,7 +149,7 @@ So the `--storage-quota` argument in `init` gets turned into the keyword argumen
 
 ```python
 api.init(
-    repository="/foor/bar",
+    repository="foor/bar",
     encryption="repokey",
     append_only=True,
     storage_quota="5G",
@@ -150,9 +166,9 @@ diff_args = {
 }
 
 api.diff(
-    "/foo/bar::tuesday",
+    "foo/bar::tuesday",
     "friday",
-    "/foo/bar",
+    "foo/bar",
     "/baz",
     **diff_args,
 )
@@ -172,20 +188,18 @@ api.diff(
 * info
 * mount
 * umount
-* key_change_passphrase (key change-passphrase)
-* key_export (key export)
-* key_import (key import)
+* key change-passphrase (key_change_passphrase)
+* key export (key_export)
+* key import (key_import)
 * upgrade
-* export_tar
+* recreate
+* immport-tar (immport_tar)
+* export-tar (export_tar)
 * serve
 * config
-* with-lock
-* break-lock
-* benchmark crud
-
-### Unavailable Borg Commands
-* recreate
-  * Since this is an experimental feature there are no current plans to implament this.
+* with-lock (with_lock)
+* break-lock (break_lock)
+* benchmark crud (benchmark_crud)
 
 ### Command Quirks
 Things that were changed from the way the default borg commands work to make things a bit
@@ -210,7 +224,8 @@ which outputs the stats info as a json object, it gets written to stdout.
 
 If either `json` or `log_json` is set, it'll try to convert the tuple output to json.
 If it is unable and there is output that is captured it'll return the plaintext value.
-If no output is captured, it returns `None`.
+If no output is captured, it returns `None` if expecting a string or `{}` (an empty
+dictionary) if expection some kind of JSON output.
 
 If multiple outputs are requested at the same time (like `--stats` and `--list`) the command
 will return a dictionary with aptly named keys (`--list` key is "list"). If only one output
@@ -242,6 +257,12 @@ Commands not listed return no output (None)
   - info: `--info`
 - info
   - always returns bare value
+- recreate:
+  - list: `--list`, `--log-json`
+  - stats: `--stats`
+- import tar
+  - list: `--list`
+  - stats: `--stats`, `--json`
 - export tar
   - list: `--list`, `--log-json`
   - tar: filename == "-"
@@ -252,7 +273,7 @@ Commands not listed return no output (None)
   - always returns bare value
 
 ## Roadmap
-- Start work on Borg's beta branch chagnes and keeping up with those
+- Start work on Borg's beta branch again and keeping up with those
 
 ## Links
 * [PyPi Project](https://pypi.org/project/borgapi)

--- a/borgapi/__init__.py
+++ b/borgapi/__init__.py
@@ -1,5 +1,45 @@
-"""Interface for BorgBackup"""
-__all__ = ["borgapi", "options"]
+"""Interface for BorgBackup."""
 
-from .borgapi import *
-from .options import *
+__all__ = [
+    "BorgAPI",
+    "BorgAPIAsync",
+    "CommonOptions",
+    "ExclusionOptions",
+    "ExclusionInput",
+    "ExclusionOutput",
+    "FilesystemOptions",
+    "ArchiveOptions",
+    "ArchiveInput",
+    "ArchivePattern",
+    "ArchiveOutput",
+    "CommandOptions",
+    "Json",
+    "Output",
+    "Options",
+    "OutputOptions",
+    "ListStringIO",
+    "PersistantHandler",
+    "BorgLogCapture",
+    "OutputCapture",
+]
+
+from .borgapi import BorgAPI as BorgAPI
+from .borgapi import BorgAPIAsync as BorgAPIAsync
+from .capture import BorgLogCapture as BorgLogCapture
+from .capture import ListStringIO as ListStringIO
+from .capture import OutputCapture as OutputCapture
+from .capture import OutputOptions as OutputOptions
+from .capture import PersistantHandler as PersistantHandler
+from .helpers import Json as Json
+from .helpers import Options as Options
+from .helpers import Output as Output
+from .options import ArchiveInput as ArchiveInput
+from .options import ArchiveOptions as ArchiveOptions
+from .options import ArchiveOutput as ArchiveOutput
+from .options import ArchivePattern as ArchivePattern
+from .options import CommandOptions as CommandOptions
+from .options import CommonOptions as CommonOptions
+from .options import ExclusionInput as ExclusionInput
+from .options import ExclusionOptions as ExclusionOptions
+from .options import ExclusionOutput as ExclusionOutput
+from .options import FilesystemOptions as FilesystemOptions

--- a/borgapi/capture.py
+++ b/borgapi/capture.py
@@ -1,0 +1,416 @@
+"""Save Borg output to review after command call."""
+
+import logging
+import sys
+from dataclasses import dataclass
+from io import BytesIO, StringIO, TextIOWrapper
+from types import TracebackType
+from typing import Optional, Union
+
+try:
+    from typing import Self
+except ImportError:
+    # Self isn't added to the typing library until version 3.11
+    from typing import TypeVar
+
+    Self = TypeVar("Self", bound="OutputCapture")
+
+from borg.logger import JsonFormatter
+
+from .helpers import Json
+
+__all__ = ["OutputOptions", "ListStringIO", "PersistantHandler", "BorgLogCapture", "OutputCapture"]
+
+LOG_LVL = "warning"
+
+
+@dataclass
+class OutputOptions:
+    """Settings for what output should be saved."""
+
+    raw_bytes: bool = False
+    log_lvl: str = LOG_LVL
+    log_json: bool = False
+    list_show: bool = False
+    list_json: bool = False
+    stats_show: bool = False
+    stats_json: bool = False
+    repo_show: bool = False
+    repo_json: bool = False
+    prog_show: bool = False
+    prog_json: bool = False
+
+
+class ListStringIO(StringIO):
+    """Save TextIO to a list of single lines."""
+
+    def __init__(self, initial_value="", newline="\n"):
+        r"""Wrap StringIO to gobble written data and save to a list.
+
+        :param initial_value: Initial value of buffer, passed to StringIO, defaults to ''
+        :type initial_value: str, optional
+        :param newline: What character to use for newlines, passed to StringIO, defaults to '\\n'
+        :type newline: str, optional
+        """
+        super().__init__(initial_value=initial_value, newline=newline)
+        self.values = list()
+        self.idx = 0
+
+    def write(self, s: str, /):
+        """Gobble written data and save it to a list right away.
+
+        :param s: data to write to output
+        :type s: str
+        """
+        super().write(s)
+        self.flush()
+        val = self.getvalue()
+        self.seek(0)
+        self.truncate()
+        dvals = val.replace("\r", "\n").splitlines(keepends=True)
+        vals = []
+        for v in dvals:
+            nv = v.rstrip()
+            if v[-1] == "\n":
+                nv = f"{nv}\n"
+            if nv:
+                vals.append(nv)
+        if vals and self.values and self.values[-1][-1] != "\n":
+            self.values[-1] = self.values[-1] + vals[0]
+            self.values.extend(vals[1:])
+        else:
+            self.values.extend(vals)
+
+    def get(self) -> str:
+        """Get next line of output data.
+
+        :return: Next line of output, None if end of list
+            and no new lines
+        :rtype: str
+        """
+        if self.idx >= len(self.values):
+            return None
+        rec = self.values[self.idx]
+        self.idx += 1
+        return rec
+
+    def get_all(self) -> list[str]:
+        """Get all data that has been written so far.
+
+        :return: all lines written to output split on newlines
+        :rtype: list[str]
+        """
+        return self.values
+
+
+class PersistantHandler(logging.Handler):
+    """Save logged information into a list of records."""
+
+    def __init__(self, json: bool = False):
+        """Prep handler to be attached to a :class:`logging.Logger`.
+
+        :param json: if the output should be saved as a json value
+            instead of a string, defaults to False
+        :type json: bool, optional
+        """
+        super().__init__()
+        self.records = list()
+        self.idx = 0
+        self.closed = False
+
+        self.json = json
+
+        fmt = "%(message)s"
+        formatter = JsonFormatter(fmt) if json else logging.Formatter(fmt)
+        self.setFormatter(formatter)
+        self.setLevel("INFO")
+
+    def emit(self, record: logging.LogRecord):
+        """Log the record to the handlers internal list.
+
+        Implements `logger.Handler.emit`. Should not be manually called.
+
+        :param record: Logging record to be saved to the list.
+        :type record: logging.LogRecord
+        """
+        try:
+            formatted = self.format(record)
+            if not self.json:
+                formatted = formatted.rstrip()
+            if formatted:
+                self.records.append(formatted)
+        except Exception:
+            self.handleError(record)
+
+    def get(self) -> Union[str, Json]:
+        """Retrieve the next record in the list.
+
+        :return: Next item in the list if there is one available, otherwise `None`
+        :rtype: Union[str, Json, None]
+        """
+        if self.idx >= len(self.records):
+            return None
+        rec = self.records[self.idx]
+        self.idx += 1
+        return rec
+
+    def get_all(self) -> list[Union[str, Json]]:
+        """Retrieve full list of records.
+
+        :return: _description_
+        :rtype: list[Union[str, Json]]
+        """
+        return self.records
+
+    def get_rest(self) -> list[Union[str, Json]]:
+        """Retrieve remaining records starting at current index.
+
+        :return: Unretrieved records in the list
+        :rtype: list[Union[str, Json]]
+        """
+        if self.idx < len(self.records):
+            return self.records[self.idx :]
+        return []
+
+    def __str__(self):
+        """Join every record saved with newlines.
+
+        :return: String of the records saved.
+        :rtype: str
+        """
+        return "\n".join([str(r) for r in self.records])
+
+    def value(self):
+        """Return the records based on the output type (json or string).
+
+        :return: All records in pretty-ish format
+        :rtype: Union[str, list[Json]]
+        """
+        if self.json:
+            return self.records
+        return str(self)
+
+    def close(self):
+        """Set a flag to know if any new records should be expected.
+
+        When `self.closed` is `True`, then no new records will be written
+        to the logger.
+        """
+        self.closed = True
+
+    def seek(self, idx: int = 0):
+        """Set the index for getting the next record.
+
+        Writing records always go to the end of the list.
+
+        :param idx: position to start getting records from next, defaults to 0
+        :type idx: int, optional
+        """
+        self.idx = idx
+
+
+class BorgLogCapture:
+    """Capture Borgs output to review after a command call."""
+
+    def __init__(self, logger: str, log_json: bool = False):
+        """Attach handler to specified logger to gather output data.
+
+        :param logger: Logger to get information from.
+        :type logger: str
+        :param log_json: save data as a json instead of a string, defaults to False
+        :type log_json: bool, optional
+        """
+        self.logger = logging.getLogger(logger)
+        self.handler = PersistantHandler(log_json)
+        self.logger.addHandler(self.handler)
+
+    def get(self) -> Optional[Union[str, Json]]:
+        """Get next value in the handler.
+
+        :return: Next value to read from the handler if it exists.
+            Otherwise will return None.
+        :rtype: Optional[str]
+        """
+        return self.handler.get()
+
+    def get_all(self) -> list[Union[str, Json]]:
+        """Get every logged record since the handler was attached.
+
+        :return: list of each record entry
+        :rtype: list
+        """
+        return self.handler.get_all()
+
+    def value(self):
+        """Get full data from handler.
+
+        :return: the full output of the data
+        :rtype: str or dict
+        """
+        return self.handler.value()
+
+    def close(self):
+        """Close handler and remove it from logger."""
+        self.handler.close()
+        self.logger.removeHandler(self.handler)
+
+    def __str__(self):
+        """Join all lines together as single string block.
+
+        :return: String of all data logged to handler
+        :rtype: str
+        """
+        return "\n".join(self.get_all())
+
+
+class OutputCapture:
+    """Capture stdout and stderr by redirecting to inmemory streams.
+
+    :param raw: Expecting raw bytes from stdout and stderr
+    :type raw: bool
+    """
+
+    def __init__(self):
+        """Create object to log Borg output."""
+        self.ready = False
+
+    def __call__(self, opts: OutputOptions) -> Self:
+        """Create handlers to use by a context manager.
+
+        Clears out old handlers from previous calls and creates new
+        ones for next Borg command to be used.
+
+        :param opts: Display options
+        :type opts: OutputOptions
+        :return: After setup, the object needs to be pased to the context manager.
+        :rtype: Self
+        """
+        self.ready = False
+        self.opts = opts
+        self.raw = self.opts.raw_bytes
+        self._init_stdout(self.raw)
+        self._init_stderr()
+
+        self.list_capture = None
+        if self.opts.list_show:
+            self.list_capture = BorgLogCapture("borg.output.list", self.opts.list_json)
+
+        self.stats_capture = None
+        if self.opts.stats_show:
+            self.stats_capture = BorgLogCapture("borg.output.stats", self.opts.stats_json)
+
+        self.repo_capture = None
+        if self.opts.repo_show:
+            self.repo_capture = BorgLogCapture("borg.repository", self.opts.repo_json)
+
+        self.ready = True
+
+        return self
+
+    def _init_stdout(self, raw: bool):
+        self._stdout = TextIOWrapper(BytesIO()) if raw else ListStringIO()
+        self.stdout_original = sys.stdout
+        sys.stdout = self._stdout
+
+    def _init_stderr(self):
+        self._stderr = ListStringIO()
+        self.stderr_original = sys.stderr
+        sys.stderr = self._stderr
+
+    def getvalues(self) -> Union[str, bytes]:
+        """Get the captured values from the redirected stdout and stderr.
+
+        :return: Redirected values from stdout and stderr
+        :rtype: Union[str, bytes]
+        """
+        output = {}
+
+        if self.raw:
+            stdout_value = self._stdout.buffer.getvalue()
+        else:
+            stdout_value = "".join(self._stdout.get_all())
+        output["stdout"] = stdout_value
+        output["stderr"] = "".join(self._stderr.get_all())
+
+        if self.opts.list_show:
+            output["list"] = self.list_capture.value()
+        if self.opts.stats_show:
+            output["stats"] = self.stats_capture.value()
+        if self.opts.repo_show:
+            output["repo"] = self.repo_capture.value()
+
+        return output
+
+    def close(self):
+        """Close the underlying IO streams and reset stdout and stderr."""
+        try:
+            if not self.raw:
+                self._stdout.close()
+            self._stderr.close()
+            if self.list_capture:
+                self.list_capture.close()
+            if self.stats_capture:
+                self.stats_capture.close()
+            if self.repo_capture:
+                self.repo_capture.close()
+        finally:
+            sys.stdout = self.stdout_original
+            sys.stderr = self.stderr_original
+            self.ready = False
+
+    def __enter__(self) -> Self:
+        """Return the runtime context.
+
+        No additional work needs to be done when entering a context.
+
+        :return: Get `self` to use in a context
+        :rtype: Self
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> bool:
+        """Cleanup the capture when finished with a `with` context.
+
+        Don't want to hide any exceptions during the context, so a return
+        value of `True`
+
+        :param exc_type: exception type
+        :type exc_type: Optional[type[BaseException]]
+        :param exc_value: exception that was raised
+        :type exc_value: Optional[BaseException]
+        :param traceback: traceback of the exception that was raised
+        :type traceback: Optional[TracebackType]
+        :return: Propogates any exception that happens during runtime.
+        :rtype: bool
+        """
+        self.close()
+        return False
+
+    def list(self):
+        """Get buffer where list information is being logged."""
+        return self.list_capture
+
+    def stats(self):
+        """Get buffer where stats are being logged."""
+        return self.stats_capture
+
+    def repository(self):
+        """Get buffer where repository info is being logged."""
+        return self.repo_capture
+
+    def progress(self):
+        """Get buffer where progress is being logged."""
+        return self._stderr
+
+    def stdout(self):
+        """Get buffer stdout is being logged."""
+        return self._stdout.buffer if self.raw else self._stdout
+
+    def stderr(self):
+        """Get buffer stderr is being logged."""
+        return self._stderr

--- a/borgapi/helpers.py
+++ b/borgapi/helpers.py
@@ -1,0 +1,26 @@
+"""Assortment of methods to help with debugging."""
+
+import sys
+from typing import Any, Union
+
+__all__ = ["Json", "Output", "Options"]
+
+Json = Union[list, dict]
+Output = Union[str, Json, None]
+Options = Union[bool, str, int]
+
+ENVIRONMENT_DEFAULTS = {
+    "BORG_EXIT_CODES": "modern",
+    "BORG_PASSPHRASE": "",
+    "BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK": "no",
+    "BORG_RELOCATED_REPO_ACCESS_IS_OK": "no",
+    "BORG_CHECK_I_KNOW_WHAT_I_AM_DOING": "NO",
+    "BORG_DELETE_I_KNOW_WHAT_I_AM_DOING": "NO",
+}
+
+
+def force(*vals: Any) -> None:
+    """Force print to stdout python started with."""
+    out = " ".join([str(v) for v in vals])
+    sys.__stdout__.write(out + "\n")
+    return sys.__stdout__.flush()

--- a/borgapi/options.py
+++ b/borgapi/options.py
@@ -1,4 +1,4 @@
-"""Option Dataclasses"""
+"""Option Dataclasses."""
 
 import logging
 import re
@@ -23,7 +23,7 @@ __all__ = [
 
 @dataclass
 class _DefaultField:
-    """Field info in options classes"""
+    """Field info in options classes."""
 
     name: str
     type: type
@@ -32,7 +32,7 @@ class _DefaultField:
 
 @dataclass
 class OptionsBase:
-    """Holds all the shared methods for the subclasses
+    """Holds all the shared methods for the subclasses.
 
     Every subclass should use this __init__ method becuase it will only set the values that the
     dataclass supports and ignore the ones not part of it. This way the same options dict can be
@@ -40,6 +40,7 @@ class OptionsBase:
     """
 
     def __init__(self, **kwargs):
+        """Set options to be used for the subclasses."""
         default = self._defaults()
         for option in kwargs:
             if option in default:
@@ -47,11 +48,10 @@ class OptionsBase:
 
     @staticmethod
     def convert_name(value: str) -> str:
-        """Add flag marker and replace underscores with dashes in name"""
+        """Add flag marker and replace underscores with dashes in name."""
         return "--" + value.replace("_", "-")
 
     def _field_set(self, field: str) -> bool:
-        # pylint: disable=no-member
         default = self.__dataclass_fields__.get(field).default
         set_value = getattr(self, field)
         return set_value != default
@@ -67,7 +67,6 @@ class OptionsBase:
             else:
                 logger.warning("[DEPRECATED] %s, not being replaced", old_field)
 
-    # pylint: disable=no-member
     @classmethod
     def _defaults(cls) -> Set[str]:
         defaults = set()
@@ -83,13 +82,13 @@ class OptionsBase:
             return issubclass(type_.__origin__, list)
 
     def parse(self) -> List[Optional[Union[str, int]]]:
-        """Turn options into list for argv
+        """Turn options into list for argv.
 
         :return: options for the command line
         :rtype: List[Optional[Union[str, int]]]
         """
         args = []
-        # pylint: disable=no-member
+
         for key, value in self.__dataclass_fields__.items():
             attr = getattr(self, key)
             if attr is not None and value.default != attr:
@@ -107,10 +106,9 @@ class OptionsBase:
         return args
 
 
-# pylint: disable=too-many-instance-attributes
 @dataclass
 class CommonOptions(OptionsBase):
-    """Common Options for all Borg commands
+    """Common Options for all Borg commands.
 
     :param critical: work on log level CRITICAL
     :type critical: bool
@@ -174,8 +172,8 @@ class CommonOptions(OptionsBase):
     debug_profile: str = None
     rsh: str = None
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the common options for all commands."""
         super().__init__(**kwargs)
 
         if isinstance(self.debug_topic, str):
@@ -186,7 +184,7 @@ class CommonOptions(OptionsBase):
 
 @dataclass
 class ExclusionOptions(OptionsBase):
-    """Options for excluding various files from backup
+    """Options for excluding various files from backup.
 
     :param exclude: exclude paths matching PATTERN
     :type exclude: List[str]
@@ -204,8 +202,8 @@ class ExclusionOptions(OptionsBase):
     pattern: List[str] = None
     patterns_from: str = None
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the exclusion options for many commands."""
         super().__init__(**kwargs)
 
         if isinstance(self.exclude, str):
@@ -216,7 +214,7 @@ class ExclusionOptions(OptionsBase):
 
 @dataclass
 class ExclusionInput(ExclusionOptions):
-    """Exclusion Options when inputing data to the archive
+    """Exclusion Options when inputing data to the archive.
 
     :param exclude_caches: exclude directories that contain a CACHEDIR.TAG file
         (http://www.bford.info/cachedir/spec.html)
@@ -239,8 +237,8 @@ class ExclusionInput(ExclusionOptions):
     keep_tag_files: bool = False
     exclude_nodump: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the exclusion options for input for many commands."""
         super().__init__(**kwargs)
 
         if isinstance(self.exclude_if_present, str):
@@ -249,7 +247,7 @@ class ExclusionInput(ExclusionOptions):
 
 @dataclass
 class ExclusionOutput(ExclusionOptions):
-    """Exclusion Options when outputing data in the archive
+    """Exclusion Options when outputing data in the archive.
 
     :param strip_componts: Remove the specified number of leading path elements. Paths with fewer
         elements will be silently skipped
@@ -258,14 +256,14 @@ class ExclusionOutput(ExclusionOptions):
 
     strip_componts: int = None
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the exclusion options for output for many commands."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class FilesystemOptions(OptionsBase):
-    """Options for how to handle filesystem attributes
+    """Options for how to handle filesystem attributes.
 
     :param one_file_system: stay in the same file system and do not store mount points of other
         file systems. This might behave different from your expectations, see the docs.
@@ -306,23 +304,23 @@ class FilesystemOptions(OptionsBase):
     files_cache: str = None
     read_special: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the filesystem options for many commands."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class ArchiveOptions(OptionsBase):
-    """Options related to the archive"""
+    """Options related to the archive."""
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the archive options for many commands."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class ArchiveInput(ArchiveOptions):
-    """Archive Options when inputing data to the archive
+    """Archive Options when inputing data to the archive.
 
     :param comment: add a comment text to the archive
     :type comment: str
@@ -345,14 +343,14 @@ class ArchiveInput(ArchiveOptions):
     chunker_params: str = None
     compression: str = None
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the input options for archives for many commands."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class ArchivePattern(ArchiveOptions):
-    """Archive Options when outputing data in the archive
+    """Archive Options when outputing data in the archive.
 
     :param prefix: only consider archive names starting with this prefix.
     :type prefix: str
@@ -365,14 +363,14 @@ class ArchivePattern(ArchiveOptions):
     prefix: str = None
     glob_archives: str = None
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the output pattern options for archives many commands."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class ArchiveOutput(ArchivePattern):
-    """Archive options when filtering output
+    """Archive options when filtering output.
 
     :param sort_by: Comma-separated list of sorting keys; valid keys are: timestamp, name, id;
         default is: timestamp
@@ -387,14 +385,14 @@ class ArchiveOutput(ArchivePattern):
     first: int = None
     last: int = None
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the output options for archives many commands."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class InitOptional(OptionsBase):
-    """Init command options
+    """Init command options.
 
     :param append_only: create an append-only mode repository
     :type append_only: bool
@@ -410,15 +408,14 @@ class InitOptional(OptionsBase):
     storage_quota: str = None
     make_parent_dirs: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `init` command."""
         super().__init__(**kwargs)
 
 
-# pylint: disable=too-many-instance-attributes
 @dataclass
 class CreateOptional(OptionsBase):
-    """Create command options
+    """Create command options.
 
     :param dry_run: do not create a backup archive
     :type dry_run: bool
@@ -462,14 +459,14 @@ class CreateOptional(OptionsBase):
     stdin_group: str = None
     stdin_mode: str = None
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `create` command."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class ExtractOptional(OptionsBase):
-    """Extract command options
+    """Extract command options.
 
     :param list: output verbose list of items (files, dirs, …)
     :type list: bool
@@ -498,14 +495,14 @@ class ExtractOptional(OptionsBase):
     stdout: bool = False
     sparse: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `extract` command."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class CheckOptional(OptionsBase):
-    """Check command options
+    """Check command options.
 
     :param repository_only: only perform repository checks
     :type repository_only: bool
@@ -526,14 +523,14 @@ class CheckOptional(OptionsBase):
     repair: bool = False
     save_space: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `check` command."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class ListOptional(OptionsBase):
-    """List command options
+    """List command options.
 
     :param short: only print file/directory names, nothing else
     :type short: bool
@@ -557,14 +554,14 @@ class ListOptional(OptionsBase):
     json: bool = False
     json_lines: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `list` command."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class DiffOptional(OptionsBase):
-    """Diff command options
+    """Diff command options.
 
     :param numeric_owner: only consider numeric user and group identifiers
     :type numeric_owner: bool
@@ -581,8 +578,8 @@ class DiffOptional(OptionsBase):
     sort: bool = False
     json_lines: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `diff` command."""
         super().__init__(**kwargs)
 
         self._log_deprecated("numeric_owner", "numeric_ids")
@@ -590,7 +587,7 @@ class DiffOptional(OptionsBase):
 
 @dataclass
 class DeleteOptional(OptionsBase):
-    """Delete command options
+    """Delete command options.
 
     :param dry_run: do not change repository
     :type dry_run: bool
@@ -605,20 +602,22 @@ class DeleteOptional(OptionsBase):
     """
 
     dry_run: bool = False
+    list: bool = False
     stats: bool = False
     cache_only: bool = False
     force: bool = False
+    keep_security_info: bool = False
     save_space: bool = False
+    checkpoint_interval: int = 1800
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `delete` command."""
         super().__init__(**kwargs)
 
 
-# pylint: disable=too-many-instance-attributes
 @dataclass
 class PruneOptional(OptionsBase):
-    """Prune command options
+    """Prune command options.
 
     :param dry_run: do not change repository
     :type dry_run: bool
@@ -665,14 +664,14 @@ class PruneOptional(OptionsBase):
     keep_yearly: int = None
     save_space: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `prune` command."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class CompactOptional(OptionsBase):
-    """Compact command options
+    """Compact command options.
 
     :param cleanup_commits: cleanup commit-only 17-byte segment files
     :type cleanup_commits: bool
@@ -683,14 +682,14 @@ class CompactOptional(OptionsBase):
     cleanup_commits: bool = False
     threshold: int = 10
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `compact` command."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class InfoOptional(OptionsBase):
-    """Info command options
+    """Info command options.
 
     :param json: format output as JSON
     :type json: bool
@@ -698,15 +697,14 @@ class InfoOptional(OptionsBase):
 
     json: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `info` command."""
         super().__init__(**kwargs)
 
 
-# pylint: disable=invalid-name
 @dataclass
 class MountOptional(OptionsBase):
-    """Mount command options
+    """Mount command options.
 
     :param foreground: stay in foreground, do not daemonize
     :type foreground: bool
@@ -717,14 +715,14 @@ class MountOptional(OptionsBase):
     foreground: bool = True
     o: str = None
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `mount` command."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class KeyExportOptional(OptionsBase):
-    """Key Export command options
+    """Key Export command options.
 
     :param paper: create an export suitable for printing and later type-in
     :type paper: bool
@@ -735,14 +733,14 @@ class KeyExportOptional(OptionsBase):
     paper: bool = False
     qr_html: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `key export` command."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class KeyImportOptional(OptionsBase):
-    """Key Import command options
+    """Key Import command options.
 
     :param paper: interactively import from a backup done with `paper`
     :type paper: bool
@@ -750,14 +748,14 @@ class KeyImportOptional(OptionsBase):
 
     paper: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `key import` command."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class UpgradeOptional(OptionsBase):
-    """Upgrade command options
+    """Upgrade command options.
 
     :param dry_run: do not change repository
     :type dry_run: bool
@@ -778,14 +776,79 @@ class UpgradeOptional(OptionsBase):
     tam: bool = False
     disable_tam: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `upgrade` command."""
+        super().__init__(**kwargs)
+
+
+@dataclass
+class RecreateOptional(OptionsBase):
+    """Recreate command options.
+
+    :param list: output verbose list of items (files, dirs, …)
+    :type list: bool
+    :param filter: only display items with the given status characters
+        (listed in borg create --help)
+    :type filter: str
+    :param dry_run: do not change anything
+    :type dry_run: bool
+    :param stats: print statistics at end
+    :type stats: bool
+    :param target: create a new archive with the name ARCHIVE, do not replace existing archive
+        (only applies for a single archive)
+    :type target: str
+    :param recompress: recompress data chunks according to MODE and --compression. Possible modes
+        are `if-different`, `always`, `never`. If no MODE is given, if-different will be used.
+    :type recompress: str
+    """
+
+    list: bool = False
+    filter: str = None
+    dry_run: bool = False
+    stats: bool = False
+
+    # Custom Archive Options
+    target: str = None
+    recompress: str = None
+
+    def __init__(self, **kwargs):
+        """Set the options for the `recreate` command."""
+        super().__init__(**kwargs)
+
+
+@dataclass
+class ImportTarOptional(OptionsBase):
+    """Import Tar command options.
+
+    :param tar_filter: filter program to pipe data through
+    :type tar_filter: str
+    :param stats: print statistics for the created archive
+    :type stats: bool
+    :param list: output verbose list of items (files, dirs, …)
+    :type list: bool
+    :param filter: only display items with the given status characters
+    :type filter: str
+    :param json: output stats as JSON. Implies `stats`
+    :type json: bool
+    :param ignore_zeros: ignore zero-filled blocks in the input tarball
+    :type ignore_zeros: bool
+    """
+
+    tar_filter: str = None
+    stats: bool = False
+    list: bool = False
+    filter: str = None
+    json: bool = False
+    ignore_zeros: bool = False
+
+    def __init__(self, **kwargs):
+        """Set the options for the `import-tar` command."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class ExportTarOptional(OptionsBase):
-    """Export Tar command options
+    """Export Tar command options.
 
     :param tar_filter: filter program to pipe data through
     :type tar_filter: str
@@ -796,14 +859,14 @@ class ExportTarOptional(OptionsBase):
     tar_filter: str = None
     list: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `export-tar` command."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class ServeOptional(OptionsBase):
-    """Serve command options
+    """Serve command options.
 
     :param restrict_to_path: restrict repository access to PATH.
         Can be specified multiple times to allow the client access to several directories.
@@ -831,14 +894,14 @@ class ServeOptional(OptionsBase):
     append_only: bool = False
     storage_quota: str = None
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `serve` command."""
         super().__init__(**kwargs)
 
 
 @dataclass
 class ConfigOptional(OptionsBase):
-    """Config command options
+    """Config command options.
 
     :param cache: get and set values from the repo cache
     :type cache: bool
@@ -852,13 +915,13 @@ class ConfigOptional(OptionsBase):
     delete: bool = False
     list: bool = False
 
-    # pylint: disable=useless-super-delegation
     def __init__(self, **kwargs):
+        """Set the options for the `config` command."""
         super().__init__(**kwargs)
 
 
 class CommandOptions:
-    """Optional Arguments for the different commands"""
+    """Optional Arguments for the different commands."""
 
     optional_classes = {
         "init": InitOptional,
@@ -875,12 +938,19 @@ class CommandOptions:
         "key_export": KeyExportOptional,
         "key_import": KeyImportOptional,
         "upgrade": UpgradeOptional,
+        "recreate": RecreateOptional,
+        "import_tar": ImportTarOptional,
         "export_tar": ExportTarOptional,
         "serve": ServeOptional,
         "config": ConfigOptional,
     }
 
     def __init__(self, defaults: dict = None):
+        """Set the defaults used for all commands.
+
+        :param defaults: Specific flags to use for all commands, defaults to None
+        :type defaults: dict, optional
+        """
         self.defaults = defaults or {}
 
     @classmethod
@@ -893,7 +963,7 @@ class CommandOptions:
             ) from e
 
     def get(self, command: str, values: dict) -> OptionsBase:
-        """Return OptionsBase with flags set for `command`
+        """Return OptionsBase with flags set for `command`.
 
         :param command: command being called
         :type command: str
@@ -902,12 +972,11 @@ class CommandOptions:
         :return: instance of command dataclass
         :rtype: OptionsBase
         """
-
         optionals = {**self.defaults.get(command, {}), **(values or {})}
         return self._get_optional(command)(**optionals)
 
     def to_list(self, command: str, values: dict) -> list:
-        """Parsed args list for command
+        """Parse args list for command.
 
         :param command: command name
         :type command: str

--- a/install-virtenv.sh
+++ b/install-virtenv.sh
@@ -11,32 +11,25 @@ eval "$(pyenv virtualenv-init -)"
 function update() {
     pyenv activate "$1"
     python -m pip install --upgrade pip
-    python -m pip install black pylint isort build twine
+    python -m pip install ruff~=0.9.1
     if [ -e "requirements.txt" ]; then
         python -m pip install -r requirements.txt --upgrade
     fi
     pyenv deactivate
 }
 
-## PYTHON 3.8 ##
-if test -n $(pyenv versions | grep "borglatest-3.8"); then
-    pyenv uninstall "borglatest-3.8"
-fi
-pyenv virtualenv "3.8.16"  "borglatest-3.8"
-update "borglatest-3.8"
-
 ## PYTHON 3.9 ##
 if test -n $(pyenv versions | grep "borglatest-3.9"); then
     pyenv uninstall "borglatest-3.9"
 fi
-pyenv virtualenv "3.9.16"  "borglatest-3.9"
+pyenv virtualenv "3.9.21"  "borglatest-3.9"
 update "borglatest-3.9"
 
 ## PYTHON 3.10 ##
 if test -n $(pyenv versions | grep "borglatest-3.10"); then
     pyenv uninstall "borglatest-3.10"
 fi
-pyenv virtualenv "3.10.10" "borglatest-3.10"
+pyenv virtualenv "3.10.16" "borglatest-3.10"
 update "borglatest-3.10"
 
 ## PYTHON 3.11 ##
@@ -46,4 +39,16 @@ fi
 pyenv virtualenv "3.11.2"  "borglatest-3.11"
 update "borglatest-3.11"
 
+## PYTHON 3.12 ##
+if test -n $(pyenv versions | grep "borglatest-3.12"); then
+    pyenv uninstall "borglatest-3.12"
+fi
+pyenv virtualenv "3.12.8"  "borglatest-3.12"
+update "borglatest-3.12"
 
+## PYTHON 3.13 ##
+if test -n $(pyenv versions | grep "borglatest-3.13"); then
+    pyenv uninstall "borglatest-3.13"
+fi
+pyenv virtualenv "3.13.1"  "borglatest-3.13"
+update "borglatest-3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,76 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "borgapi"
+version = "0.7.0"
+author = "Sean Slater"
+author_email = "seanslater@whatno.io"
+description = "Wrapper for borgbackup to easily use in code"
+readme = "README.md"
+url = "https://github.com/spslater/borgapi"
+license = "MIT License"
+license-files = ["LICENSE"]
+python_requires = ">=3.9"
+dependencies = [
+    "borgbackup[llfuse]~=1.4.0",
+    "python-dotenv~=1.0.0",
+]
+keywords = ["borgbackup", "backup", "api"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: OS Independent",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Utilities",
+    "Topic :: System :: Archiving :: Backup",
+]
+
+[project.urls]
+homepage = "https://github.com/spslater/borgapi"
+documentation = "https://github.com/spslater/borgapi/blob/master/README.md"
+repository = "https://github.com/spslater/borgapi.git"
+issues = "https://github.com/spslater/borgapi/issues"
+changelog = "https://github.com/spslater/borgapi/blob/master/CHANGELOG.md"
+
+[tool.ruff]
+line-length = 100
+indent-width = 4
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "D"]
+# A regular expression matching the name of dummy variables (i.e. expected to not be used).
+dummy-variable-rgx = "_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused"
+
+
+[tool.ruff.lint.pydocstyle]
+# waiting for `sphinx` convention to be available
+convention = "pep257"
+
+[tool.ruff.lint.pylint]
+# Maximum number of arguments for function / method.
+max-args = 5
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr = 5
+# Maximum number of branch for function / method body.
+max-branches = 12
+# Maximum number of locals for function / method body.
+max-locals = 15
+# Maximum number of public methods for a class (see R0904).
+max-public-methods = 20
+# Maximum number of return / yield for function / method body.
+max-returns = 6
+# Maximum number of statements in function / method body.
+max-statements = 50
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+docstring-code-format = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-borgbackup[llfuse]==1.2.4
-python-dotenv==1.0.0
+borgbackup[llfuse]~=1.4.0
+python-dotenv~=1.0.0

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,22 +1,23 @@
 #!/usr/bin/env bash
 
 versions=(
-    "borglatest-3.8"
     "borglatest-3.9"
     "borglatest-3.10"
     "borglatest-3.11"
+    "borglatest-3.12"
+    "borglatest-3.13"
 )
 
 eval "$(pyenv init -)" >/dev/null 2>&1
 eval "$(pyenv init --path)"
 eval "$(pyenv virtualenv-init -)"
 
-echo > "results.log"
+echo "Automate tests for supported Python versions" > "results.log"
 
 for version in "${versions[@]}"; do
     pyenv activate $version
     pip install -r requirements.txt 1>&2 2>/dev/null
-    printf "$version: " 1>&2 | tee -a "results.log"
+    printf "$version: " 2>&1 | tee -a "results.log"
     if test "$1" = "-v"; then
         python -m unittest discover -v 2>&1 | tee -a "results.log"
     else

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,5 @@
-"""BorgAPI Package Setup"""
+"""BorgAPI Package Setup."""
+
 import setuptools
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
-setuptools.setup(
-    name="borgapi",
-    version="0.6.1",
-    author="Sean Slater",
-    author_email="seanslater@whatno.io",
-    description="Wrapper for borgbackup to easily use in code",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/spslater/borgapi",
-    license="MIT License",
-    packages=setuptools.find_packages(),
-    install_requires=["borgbackup[llfuse]==1.2.4", "python-dotenv>=1.0.0"],
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Operating System :: OS Independent",
-        "License :: OSI Approved :: MIT License",
-        "Topic :: Utilities",
-        "Topic :: System :: Archiving :: Backup",
-    ],
-    keywords="borgbackup backup api",
-    python_requires=">=3.8",
-)
+setuptools.setup()

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+"""BorgAPI testing module."""

--- a/test/borgapi/__init__.py
+++ b/test/borgapi/__init__.py
@@ -1,0 +1,194 @@
+# ruff: noqa: N802
+"""Test BorgAPI module."""
+
+import unittest
+from configparser import ConfigParser
+from os import getenv, makedirs, remove
+from os.path import exists, join
+from shutil import rmtree
+
+from dotenv import load_dotenv
+
+from borgapi import BorgAPI, BorgAPIAsync
+
+
+class BorgapiTests(unittest.TestCase):
+    """Test for the borgbackup api."""
+
+    @staticmethod
+    def assertFileExists(path, msg=None):
+        """Assert if a path exists or not."""
+        if not exists(path):
+            raise AssertionError(msg or f"{path} does not exist")
+
+    @staticmethod
+    def assertFileNotExists(path, msg=None):
+        """Assert if a path exists or not."""
+        if exists(path):
+            raise AssertionError(msg or f"{path} does exist")
+
+    @staticmethod
+    def assertKeyExists(key, dictionary, msg=None):
+        """Assert a key exists in a dictionary."""
+        if key not in dictionary:
+            raise AssertionError(msg or f"{key} does not exist in dictionary")
+
+    @staticmethod
+    def assertKeyNotExists(key, dictionary, msg=None):
+        """Assert a key does not exist in a dictionary."""
+        if key in dictionary:
+            raise AssertionError(msg or f"{key} exists in dictionary")
+
+    @staticmethod
+    def assertType(obj, type_, msg=None):
+        """Assert an object is an instance of type."""
+        if not isinstance(obj, type_):
+            raise AssertionError(msg or f"{obj} is not type {type_}, it is {type(obj)}")
+
+    @staticmethod
+    def assertAnyType(obj, *types, msg=None):
+        """Assert an object is an instance of type."""
+        if not any([isinstance(obj, t) for t in types]):
+            raise AssertionError(msg or f"{obj} is not any of {types}; it is {type(obj)}")
+
+    @staticmethod
+    def assertSubclass(obj, class_, msg=None):
+        """Assert an object is an subclass of class."""
+        if not issubclass(obj, class_):
+            raise AssertionError(msg or f"{obj} is not a subtype of {class_}")
+
+    @staticmethod
+    def assertNone(obj, msg=None):
+        """Assert an object is None."""
+        if obj is not None:
+            raise AssertionError(msg or f"Value is not None: {obj}")
+
+    @staticmethod
+    def assertNotNone(obj, msg=None):
+        """Assert an object is None."""
+        if obj is None:
+            raise AssertionError(msg or "Value is None")
+
+    @staticmethod
+    def _try_pass(error, func, *args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except error:
+            pass
+
+    @staticmethod
+    def _make_clean(directory):
+        try:
+            makedirs(directory)
+        except FileExistsError:
+            rmtree(directory)
+            makedirs(directory)
+
+    @staticmethod
+    def _read_config(string=None, filename=None):
+        """Convert config string into dictionary."""
+        config = ConfigParser()
+        if filename:
+            with open(filename, "r") as fp:
+                config.read_file(fp)
+        else:
+            config.read_string(string)
+        return config
+
+    @staticmethod
+    def _display(header, output, single=True):
+        """Display captured output."""
+        if getenv("BORGAPI_TEST_OUTPUT_DISPLAY"):
+            print(header)
+            if single:
+                print(output)
+            else:
+                for name, value in output.items():
+                    print(f"~~~~~~~~~~ {name} ~~~~~~~~~~")
+                    print(value)
+            print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+            print()
+
+    @classmethod
+    def setUpClass(cls):
+        """Init environment for borg use."""
+        cls.temp = "test/temp"
+        cls.data = join(cls.temp, "data")
+        cls.repo = join(cls.temp, "repo")
+        cls.logs = join(cls.temp, "logs")
+
+        cls.archive = f"{cls.repo}::1"
+
+        cls._try_pass(FileNotFoundError, rmtree, cls.data)
+        cls._try_pass(FileNotFoundError, rmtree, cls.repo)
+        if not getenv("BORGAPI_TEST_KEEP_LOGS"):
+            cls._try_pass(FileNotFoundError, rmtree, cls.logs)
+
+        cls.file_1 = join(cls.data, "file_1.txt")
+        cls.file_1_text = "Hello World"
+        cls.file_2 = join(cls.data, "file_2.txt")
+        cls.file_2_text = "Goodbye Fools"
+        cls.file_3 = join(cls.data, "file_3.txt")
+        cls.file_3_text = "New File Added"
+
+        cls._try_pass(FileExistsError, makedirs, cls.data)
+        cls._try_pass(FileExistsError, makedirs, cls.repo)
+        cls._try_pass(FileExistsError, makedirs, cls.logs)
+        load_dotenv("test/res/test_env")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove temp directory."""
+        if not getenv("BORGAPI_TEST_KEEP_LOGS") and not getenv("BORGAPI_TEST_KEEP_TEMP"):
+            cls._try_pass(FileNotFoundError, rmtree, cls.temp)
+            cls._try_pass(OSError, rmtree, cls.temp)
+
+    def _setUp(self):
+        self._try_pass(FileExistsError, makedirs, self.temp)
+        self._try_pass(FileExistsError, makedirs, self.data)
+        self._try_pass(FileExistsError, makedirs, self.repo)
+        self._try_pass(FileExistsError, makedirs, self.logs)
+
+        with open(self.file_1, "w") as fp:
+            fp.write(self.file_1_text)
+        with open(self.file_2, "w") as fp:
+            fp.write(self.file_2_text)
+
+        self._try_pass(FileNotFoundError, remove, self.file_3)
+
+    def setUp(self):
+        """Init files data."""
+        self._setUp()
+
+        self.api = BorgAPI()
+        self.api.init(self.repo)
+
+    def tearDown(self):
+        """Reset mess made."""
+        if not getenv("BORGAPI_TEST_KEEP_TEMP"):
+            self._try_pass(FileNotFoundError, rmtree, self.data)
+            self._try_pass(OSError, rmtree, self.repo)
+            self._try_pass(FileNotFoundError, rmtree, self.repo)
+            if not getenv("BORGAPI_TEST_KEEP_LOGS"):
+                self._try_pass(FileNotFoundError, rmtree, self.logs)
+                self._try_pass(OSError, rmtree, self.temp)
+                self._try_pass(FileNotFoundError, rmtree, self.temp)
+
+    def _create_default(self):
+        self.api.create(self.archive, self.data)
+
+
+class BorgapiAsyncTests(unittest.IsolatedAsyncioTestCase, BorgapiTests):
+    """Test for the borgbackup api with async methods."""
+
+    def setUp(self):
+        """Init files data."""
+        self._setUp()
+
+    async def asyncSetUp(self):
+        """Init files data for async use."""
+        self.api = BorgAPIAsync()
+        await self.api.init(self.repo)
+
+    async def _create_default(self):
+        await self.api.create(self.archive, self.data)

--- a/test/borgapi/test_01_borgapi.py
+++ b/test/borgapi/test_01_borgapi.py
@@ -1,192 +1,23 @@
-"""Test borgapi module"""
+"""Test borgapi module."""
+
 import logging
 import unittest
-from configparser import ConfigParser
-from os import getenv, makedirs, remove
-from os.path import exists, join
-from shutil import rmtree
+from os import getenv
 
-from dotenv import load_dotenv
-
-from borgapi import BorgAPI
-
-
-# pylint: disable=too-many-public-methods
-class BorgapiTests(unittest.TestCase):
-    """Test for the borgbackup self.api"""
-
-    # pylint: disable=invalid-name
-    @staticmethod
-    def assertFileExists(path, msg=None):
-        """Assert if a path exists or not"""
-        if not exists(path):
-            raise AssertionError(msg or f"{path} does not exist")
-
-    @staticmethod
-    def assertFileNotExists(path, msg=None):
-        """Assert if a path exists or not"""
-        if exists(path):
-            raise AssertionError(msg or f"{path} does exist")
-
-    @staticmethod
-    def assertKeyExists(key, dictionary, msg=None):
-        """Assert a key exists in a dictionary"""
-        if key not in dictionary:
-            raise AssertionError(msg or f"{key} does not exist in dictionary")
-
-    @staticmethod
-    def assertKeyNotExists(key, dictionary, msg=None):
-        """Assert a key does not exist in a dictionary"""
-        if key in dictionary:
-            raise AssertionError(msg or f"{key} exists in dictionary")
-
-    @staticmethod
-    def assertType(obj, type_, msg=None):
-        """Assert an object is an instance of type"""
-        if not isinstance(obj, type_):
-            raise AssertionError(msg or f"{obj} is not type {type_}, it is {type(obj)}")
-
-    @staticmethod
-    def assertAnyType(obj, *types, msg=None):
-        """Assert an object is an instance of type"""
-        if not any([isinstance(obj, t) for t in types]):
-            raise AssertionError(
-                msg or f"{obj} is not any of {types}; it is {type(obj)}"
-            )
-
-    @staticmethod
-    def assertSubclass(obj, class_, msg=None):
-        """Assert an object is an subclass of class"""
-        if not issubclass(obj, class_):
-            raise AssertionError(msg or f"{obj} is not a subtype of {class_}")
-
-    @staticmethod
-    def assertNone(obj, msg=None):
-        """Assert an object is None"""
-        if obj is not None:
-            raise AssertionError(msg or f"Value is not None: {obj}")
-
-    @staticmethod
-    def assertNotNone(obj, msg=None):
-        """Assert an object is None"""
-        if obj is None:
-            raise AssertionError(msg or "Value is None")
-
-    @staticmethod
-    def _try_pass(error, func, *args, **kwargs):
-        try:
-            func(*args, **kwargs)
-        except error:
-            pass
-
-    @staticmethod
-    def _make_clean(directory):
-        try:
-            makedirs(directory)
-        except FileExistsError:
-            rmtree(directory)
-            makedirs(directory)
-
-    @staticmethod
-    def _read_config(string=None, filename=None):
-        """Convert config string into dictionary"""
-        config = ConfigParser()
-        if filename:
-            with open(filename, "r") as fp:
-                config.read_file(fp)
-        else:
-            config.read_string(string)
-        return config
-
-    @staticmethod
-    def _display(header, output, single=True):
-        """display captured output"""
-        if getenv("BORGAPI_TEST_OUTPUT_DISPLAY"):
-            print(header)
-            if single:
-                print(output)
-            else:
-                for name, value in output.items():
-                    print(f"~~~~~~~~~~ {name} ~~~~~~~~~~")
-                    print(value)
-            print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-            print()
-
-    @classmethod
-    def setUpClass(cls):
-        """Initalize environment for borg use"""
-
-        cls.temp = "test/temp"
-        cls.data = join(cls.temp, "data")
-        cls.repo = join(cls.temp, "repo")
-        cls.logs = join(cls.temp, "logs")
-
-        cls.archive = f"{cls.repo}::1"
-
-        cls._try_pass(FileNotFoundError, rmtree, cls.data)
-        cls._try_pass(FileNotFoundError, rmtree, cls.repo)
-        if not getenv("BORGAPI_TEST_KEEP_LOGS"):
-            cls._try_pass(FileNotFoundError, rmtree, cls.logs)
-
-        cls.file_1 = join(cls.data, "file_1.txt")
-        cls.file_1_text = "Hello World"
-        cls.file_2 = join(cls.data, "file_2.txt")
-        cls.file_2_text = "Goodbye Fools"
-        cls.file_3 = join(cls.data, "file_3.txt")
-        cls.file_3_text = "New File Added"
-
-        cls._try_pass(FileExistsError, makedirs, cls.data)
-        cls._try_pass(FileExistsError, makedirs, cls.repo)
-        cls._try_pass(FileExistsError, makedirs, cls.logs)
-        load_dotenv("test/res/test_env")
-
-    @classmethod
-    def tearDownClass(cls):
-        """Remove temp directory"""
-        if not getenv("BORGAPI_TEST_KEEP_LOGS") and not getenv(
-            "BORGAPI_TEST_KEEP_TEMP"
-        ):
-            cls._try_pass(FileNotFoundError, rmtree, cls.temp)
-
-    def setUp(self):
-        """Setup files data"""
-        self._try_pass(FileExistsError, makedirs, self.data)
-        self._try_pass(FileExistsError, makedirs, self.repo)
-        self._try_pass(FileExistsError, makedirs, self.logs)
-
-        with open(self.file_1, "w") as fp:
-            fp.write(self.file_1_text)
-        with open(self.file_2, "w") as fp:
-            fp.write(self.file_2_text)
-
-        self._try_pass(FileNotFoundError, remove, self.file_3)
-
-        self.api = BorgAPI()
-        self.api.init(self.repo)
-
-    def tearDown(self):
-        """Resets mess made"""
-        if not getenv("BORGAPI_TEST_KEEP_TEMP"):
-            self._try_pass(FileNotFoundError, rmtree, self.data)
-            self._try_pass(FileNotFoundError, rmtree, self.repo)
-            if not getenv("BORGAPI_TEST_KEEP_LOGS"):
-                self._try_pass(FileNotFoundError, rmtree, self.logs)
-
-    def _create_default(self):
-        self.api.create(self.archive, self.data)
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class SingleTests(BorgapiTests):
-    """Simple Command and Class Methodss tests"""
+    """Simple Command and Class Methodss tests."""
 
     def test_01_borgapi_logger(self):
-        """Verify loggers are setup correctly for borgapi"""
+        """Verify loggers are setup correctly for borgapi."""
         loggers = logging.root.manager.loggerDict
         self.assertIn("borgapi", loggers, "borgapi logger not present")
         self.assertIn("borg", loggers, "borg logger not present")
 
     def test_02_set_environ(self):
-        """Set new env variable"""
+        """Set new env variable."""
         key = "TEST_VARIABLE"
 
         with open(self.file_3, "w") as fp:
@@ -204,7 +35,7 @@ class SingleTests(BorgapiTests):
         self.assertEqual(got, self.file_2_text)
 
     def test_03_unset_environ(self):
-        """Remove env variable"""
+        """Remove env variable."""
         key = "TEST_VARIABLE"
 
         self.api.set_environ(**{key: self.file_1_text})
@@ -223,4 +54,44 @@ class SingleTests(BorgapiTests):
 
     @unittest.skip("WIP: Don't know what locking would be used for")
     def test_04_lock(self):
-        """Don't know what locking would be used for, so don't know how to test"""
+        """Don't know what locking would be used for, so don't know how to test."""
+
+
+class SingleAsyncTests(BorgapiAsyncTests):
+    """Simple Command and Class Methodss tests."""
+
+    async def test_01_set_environ(self):
+        """Set new env variable."""
+        key = "TEST_VARIABLE"
+
+        with open(self.file_3, "w") as fp:
+            fp.write(f"{key}={self.file_3_text}")
+        await self.api.set_environ(filename=self.file_3)
+        got = getenv(key)
+        self.assertEqual(got, self.file_3_text)
+
+        await self.api.set_environ(dictionary={key: self.file_1_text})
+        got = getenv(key)
+        self.assertEqual(got, self.file_1_text)
+
+        await self.api.set_environ(**{key: self.file_2_text})
+        got = getenv(key)
+        self.assertEqual(got, self.file_2_text)
+
+    async def test_02_unset_environ(self):
+        """Remove env variable."""
+        key = "TEST_VARIABLE"
+
+        await self.api.set_environ(**{key: self.file_1_text})
+        got = getenv(key)
+        self.assertEqual(got, self.file_1_text)
+        await self.api.unset_environ(key)
+        got = getenv(key)
+        self.assertFalse(got)
+
+        with open(self.file_3, "w") as fp:
+            fp.write(f"{key}={self.file_3_text}")
+        await self.api.set_environ(filename=self.file_3)
+        await self.api.unset_environ()
+        got = getenv(key)
+        self.assertFalse(got)

--- a/test/borgapi/test_02_init.py
+++ b/test/borgapi/test_02_init.py
@@ -1,26 +1,28 @@
-"""Test init command"""
+"""Test init command."""
+
 from os import urandom
 from os.path import join
 
 from borg.repository import Repository
 
-from .test_01_borgapi import BorgapiTests
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class InitTests(BorgapiTests):
-    """Init command tests"""
+    """Init command tests."""
 
     def setUp(self):
+        """Prepare data for init tests."""
         super().setUp()
         self._make_clean(self.repo)
 
     def test_01_basic(self):
-        """Initalize new repository"""
+        """Initalize new repository."""
         self.api.init(self.repo)
         self.assertFileExists(join(self.repo, "README"))
 
     def test_02_already_exists(self):
-        """Initalize a repo in a directory where one already exists"""
+        """Initalize a repo in a directory where one already exists."""
         self.api.init(self.repo)
         self.assertRaises(
             Repository.AlreadyExists,
@@ -30,7 +32,7 @@ class InitTests(BorgapiTests):
         )
 
     def test_03_path_exists(self):
-        """Initalize a repo in a directory where other data exists"""
+        """Initalize a repo in a directory where other data exists."""
         self.api.init(self.repo)
         self.assertRaises(
             Repository.PathAlreadyExists,
@@ -40,7 +42,7 @@ class InitTests(BorgapiTests):
         )
 
     def test_04_make_parent(self):
-        """Init a repo where parents don't exist with different flags"""
+        """Init a repo where parents don't exist with different flags."""
         deep_repo = join(self.repo, "make/parents")
 
         self.assertRaises(
@@ -54,7 +56,7 @@ class InitTests(BorgapiTests):
         self.assertKeyExists("repository", output, "Repository not initalzied")
 
     def test_05_storage_quota(self):
-        """Limit the size of the repo"""
+        """Limit the size of the repo."""
         self.api.init(self.repo, storage_quota="10M")
         with open(self.file_3, "wb") as fp:
             fp.write(urandom(10 * 1024 * 1024))
@@ -67,9 +69,81 @@ class InitTests(BorgapiTests):
         )
 
     def test_06_append_only(self):
-        """Repo in append only mode"""
+        """Repo in append only mode."""
         self.api.init(self.repo, append_only=True)
         output = self.api.config(self.repo, list=True)
+        config = self._read_config(output)
+        self.assertEqual(
+            config["repository"]["append_only"],
+            "1",
+            "Repo not in append_only mode",
+        )
+
+
+class InitAsyncTests(BorgapiAsyncTests):
+    """Init command tests."""
+
+    def setUp(self):
+        """Prepare data for async init tests."""
+        super().setUp()
+        # self._make_clean(self.repo)
+
+    async def asyncSetUp(self):
+        """Prepare async data for async init tests."""
+        await super().asyncSetUp()
+        self._make_clean(self.repo)
+
+    async def test_01_basic(self):
+        """Initalize new repository."""
+        await self.api.init(self.repo)
+        self.assertFileExists(join(self.repo, "README"))
+
+    async def test_02_already_exists(self):
+        """Initalize a repo in a directory where one already exists."""
+        await self.api.init(self.repo)
+        with self.assertRaises(
+            Repository.AlreadyExists,
+            msg="Duplicate repositroy overwrites old repo",
+        ):
+            await self.api.init(self.repo)
+
+    async def test_03_path_exists(self):
+        """Initalize a repo in a directory where other data exists."""
+        await self.api.init(self.repo)
+        with self.assertRaises(
+            Repository.PathAlreadyExists,
+            msg="Repositroy overwrites directory with other data",
+        ):
+            await self.api.init(self.data)
+
+    async def test_04_make_parent(self):
+        """Init a repo where parents don't exist with different flags."""
+        deep_repo = join(self.repo, "make/parents")
+
+        with self.assertRaises(
+            Repository.ParentPathDoesNotExist,
+            msg="Repository made with missing directories",
+        ):
+            await self.api.init(deep_repo)
+        await self.api.init(deep_repo, make_parent_dirs=True)
+        output = await self.api.list(deep_repo, json=True)
+        self.assertKeyExists("repository", output, "Repository not initalzied")
+
+    async def test_05_storage_quota(self):
+        """Limit the size of the repo."""
+        await self.api.init(self.repo, storage_quota="10M")
+        with open(self.file_3, "wb") as fp:
+            fp.write(urandom(10 * 1024 * 1024))
+        with self.assertRaises(
+            Repository.StorageQuotaExceeded,
+            msg="Stored more than quota allowed",
+        ):
+            await self.api.create(self.archive, self.data)
+
+    async def test_06_append_only(self):
+        """Repo in append only mode."""
+        await self.api.init(self.repo, append_only=True)
+        output = await self.api.config(self.repo, list=True)
         config = self._read_config(output)
         self.assertEqual(
             config["repository"]["append_only"],

--- a/test/borgapi/test_03_create.py
+++ b/test/borgapi/test_03_create.py
@@ -1,17 +1,18 @@
-"""Test create command"""
+"""Test create command."""
+
 import sys
 from io import BytesIO, TextIOWrapper
 
 from borg.archive import Archive
 
-from .test_01_borgapi import BorgapiTests
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class CreateTests(BorgapiTests):
-    """Create command tests"""
+    """Create command tests."""
 
     def test_01_basic(self):
-        """Create new archive"""
+        """Create new archive."""
         self.api.create(self.archive, self.data)
         output = self.api.list(self.repo, json=True)
         num_archives = len(output["archives"])
@@ -20,7 +21,7 @@ class CreateTests(BorgapiTests):
         self.assertEqual(archive_name, "1", "Archive name does not match set name")
 
     def test_02_second(self):
-        """Create second archive after data modification"""
+        """Create second archive after data modification."""
         self.api.create(self.archive, self.data)
         with open(self.file_3, "w+") as fp:
             fp.write("New Data")
@@ -35,7 +36,7 @@ class CreateTests(BorgapiTests):
         self.assertEqual(archive_2_name, "2", "Archive name does not match set name")
 
     def test_03_already_exists(self):
-        """Create an archive with an existing name"""
+        """Create an archive with an existing name."""
         self.api.create(self.archive, self.data)
         self.assertRaises(
             Archive.AlreadyExists,
@@ -45,7 +46,7 @@ class CreateTests(BorgapiTests):
         )
 
     def test_04_stdin(self):
-        """Read input from stdin and save to archvie"""
+        """Read input from stdin and save to archvie."""
         temp_stdin = TextIOWrapper(BytesIO(bytes(self.file_3_text, "utf-8")))
         sys.stdin = temp_stdin
         name = "file_3_stdin.txt"
@@ -67,14 +68,14 @@ class CreateTests(BorgapiTests):
         self.assertEqual(output["mode"], "-rwxrwxrwx", "Unexpected file mode")
 
     def test_04_output_string(self):
-        """Create string info"""
+        """Create string info."""
         output = self.api.create(self.archive, self.data, stats=True, list=True)
         self._display("create string info", output, False)
         self.assertType(output["stats"], str)
         self.assertType(output["list"], str)
 
     def test_05_output_json(self):
-        """Create json info"""
+        """Create json info."""
         output = self.api.create(
             self.archive,
             self.data,
@@ -87,14 +88,14 @@ class CreateTests(BorgapiTests):
         self.assertAnyType(output["list"], list, dict)
 
     def test_06_output_mixed_1(self):
-        """Create mixed output (stats json, list string)"""
+        """Create mixed output (stats json, list string)."""
         output = self.api.create(self.archive, self.data, json=True, list=True)
         self._display("create mixed output (stats json, list string)", output, False)
         self.assertType(output["stats"], dict)
         self.assertType(output["list"], str)
 
     def test_07_output_mixed_2(self):
-        """Create mixed output (stats string, list json)"""
+        """Create mixed output (stats string, list json)."""
         output = self.api.create(
             self.archive,
             self.data,
@@ -107,19 +108,19 @@ class CreateTests(BorgapiTests):
         self.assertAnyType(output["list"], list, dict)
 
     def test_08_list_string(self):
-        """Create list string"""
+        """Create list string."""
         output = self.api.create(self.archive, self.data, list=True)
         self._display("create list string", output)
         self.assertType(output, str)
 
     def test_09_stats_json(self):
-        """Create stats json"""
+        """Create stats json."""
         output = self.api.create(self.archive, self.data, json=True)
         self._display("create stats json", output)
         self.assertType(output, dict)
 
     def test_10_list_json(self):
-        """Create list json"""
+        """Create list json."""
         output = self.api.create(
             self.archive,
             self.data,
@@ -130,7 +131,132 @@ class CreateTests(BorgapiTests):
         self.assertAnyType(output, list, dict)
 
     def test_11_stats_string(self):
-        """Create stats string"""
+        """Create stats string."""
         output = self.api.create(self.archive, self.data, stats=True)
+        self._display("create stats string", output)
+        self.assertType(output, str)
+
+
+class CreateAsyncTests(BorgapiAsyncTests):
+    """Create command tests."""
+
+    async def test_01_basic(self):
+        """Create new archive."""
+        await self.api.create(self.archive, self.data)
+        output = await self.api.list(self.repo, json=True)
+        num_archives = len(output["archives"])
+        self.assertEqual(num_archives, 1, "Archive not saved")
+        archive_name = output["archives"][0]["name"]
+        self.assertEqual(archive_name, "1", "Archive name does not match set name")
+
+    async def test_02_second(self):
+        """Create second archive after data modification."""
+        await self.api.create(self.archive, self.data)
+        with open(self.file_3, "w+") as fp:
+            fp.write("New Data")
+        await self.api.create(f"{self.repo}::2", self.data)
+
+        output = await self.api.list(self.repo, json=True)
+        num_archives = len(output["archives"])
+        self.assertEqual(num_archives, 2, "Multiple archives not saved")
+        archive_1_name = output["archives"][0]["name"]
+        self.assertEqual(archive_1_name, "1", "Archive name does not match set name")
+        archive_2_name = output["archives"][1]["name"]
+        self.assertEqual(archive_2_name, "2", "Archive name does not match set name")
+
+    async def test_03_already_exists(self):
+        """Create an archive with an existing name."""
+        await self.api.create(self.archive, self.data)
+        with self.assertRaises(Archive.AlreadyExists):
+            await self.api.create(self.archive, self.data)
+
+    async def test_04_stdin(self):
+        """Read input from stdin and save to archvie."""
+        temp_stdin = TextIOWrapper(BytesIO(bytes(self.file_3_text, "utf-8")))
+        sys.stdin = temp_stdin
+        name = "file_3_stdin.txt"
+        mode = "0777"  # "-rwxrwxrwx"
+
+        try:
+            await self.api.create(
+                self.archive,
+                "-",
+                stdin_name=name,
+                stdin_mode=mode,
+            )
+        finally:
+            temp_stdin.close()
+            sys.stdin = sys.__stdin__
+
+        output = await self.api.list(self.archive, json_lines=True)
+        self.assertEqual(output["path"], name, "Unexpected file name")
+        self.assertEqual(output["mode"], "-rwxrwxrwx", "Unexpected file mode")
+
+    async def test_04_output_string(self):
+        """Create string info."""
+        output = await self.api.create(self.archive, self.data, stats=True, list=True)
+        self._display("create string info", output, False)
+        self.assertType(output["stats"], str)
+        self.assertType(output["list"], str)
+
+    async def test_05_output_json(self):
+        """Create json info."""
+        output = await self.api.create(
+            self.archive,
+            self.data,
+            json=True,
+            log_json=True,
+            list=True,
+        )
+        self._display("create string info", output, False)
+        self.assertType(output["stats"], dict)
+        self.assertAnyType(output["list"], list, dict)
+
+    async def test_06_output_mixed_1(self):
+        """Create mixed output (stats json, list string)."""
+        output = await self.api.create(self.archive, self.data, json=True, list=True)
+        self._display("create mixed output (stats json, list string)", output, False)
+        self.assertType(output["stats"], dict)
+        self.assertType(output["list"], str)
+
+    async def test_07_output_mixed_2(self):
+        """Create mixed output (stats string, list json)."""
+        output = await self.api.create(
+            self.archive,
+            self.data,
+            stats=True,
+            log_json=True,
+            list=True,
+        )
+        self._display("create mixed output (stats string, list json)", output, False)
+        self.assertType(output["stats"], str)
+        self.assertAnyType(output["list"], list, dict)
+
+    async def test_08_list_string(self):
+        """Create list string."""
+        output = await self.api.create(self.archive, self.data, list=True)
+        self._display("create list string", output)
+        self.assertType(output, str)
+
+    async def test_09_stats_json(self):
+        """Create stats json."""
+        output = await self.api.create(self.archive, self.data, json=True)
+        self._display("create stats json", output)
+        self.assertType(output, dict)
+
+    async def test_10_list_json(self):
+        """Create list json."""
+        output = await self.api.create(
+            self.archive,
+            self.data,
+            log_json=True,
+            list=True,
+        )
+        self._display("create list json", output)
+        self.assertAnyType(output, list, dict)
+
+    async def test_11_stats_string(self):
+        """Create stats string."""
+        output = await self.api.create(self.archive, self.data, stats=True)
         self._display("create stats string", output)
         self.assertType(output, str)

--- a/test/borgapi/test_04_extract.py
+++ b/test/borgapi/test_04_extract.py
@@ -1,18 +1,20 @@
-"""Test extract command"""
+"""Test extract command."""
+
 from os import remove
 
-from .test_01_borgapi import BorgapiTests
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class ExtractTests(BorgapiTests):
-    """Extract command tests"""
+    """Extract command tests."""
 
     def setUp(self):
+        """Prepare data for extract tests."""
         super().setUp()
         self._create_default()
 
     def test_01_basic(self):
-        """Extract file"""
+        """Extract file."""
         remove(self.file_1)
         self.assertFileNotExists(self.file_1)
 
@@ -20,7 +22,7 @@ class ExtractTests(BorgapiTests):
         self.assertFileExists(self.file_1)
 
     def test_02_not_exist(self):
-        """Extract path that does not exist"""
+        """Extract path that does not exist."""
         with self.assertLogs("borg", "WARNING") as logger:
             self.api.extract(self.archive, self.file_3)
         message = logger.records[0].getMessage()
@@ -31,7 +33,7 @@ class ExtractTests(BorgapiTests):
         )
 
     def test_03_stdout(self):
-        """Capture Extracted File"""
+        """Capture Extracted File."""
         output = self.api.extract(self.archive, self.file_1, stdout=True)
         self.assertEqual(
             output,
@@ -40,13 +42,62 @@ class ExtractTests(BorgapiTests):
         )
 
     def test_04_output_string(self):
-        """list to log"""
+        """List to log."""
         output = self.api.extract(self.archive, list=True, dry_run=True)
         self._display("extract 1", output)
         self.assertType(output, str)
 
     def test_05_output_json(self):
-        """list to json"""
+        """List to json."""
         output = self.api.extract(self.archive, log_json=True, list=True, dry_run=True)
+        self._display("extract 2", output)
+        self.assertAnyType(output, list, dict)
+
+
+class ExtractAsyncTests(BorgapiAsyncTests):
+    """Extract command tests."""
+
+    async def asyncSetUp(self):
+        """Prepare async data for async extract tests."""
+        await super().asyncSetUp()
+        await self._create_default()
+
+    async def test_01_basic(self):
+        """Extract file."""
+        remove(self.file_1)
+        self.assertFileNotExists(self.file_1)
+
+        await self.api.extract(self.archive, self.file_1)
+        self.assertFileExists(self.file_1)
+
+    async def test_02_not_exist(self):
+        """Extract path that does not exist."""
+        with self.assertLogs("borg", "WARNING") as logger:
+            await self.api.extract(self.archive, self.file_3)
+        message = logger.records[0].getMessage()
+        self.assertRegex(
+            message,
+            r".*?file_3.*never",
+            "Warning not logged for bad path",
+        )
+
+    async def test_03_stdout(self):
+        """Capture Extracted File."""
+        output = await self.api.extract(self.archive, self.file_1, stdout=True)
+        self.assertEqual(
+            output,
+            bytes(self.file_1_text, "utf-8"),
+            "Extracted file text does not match",
+        )
+
+    async def test_04_output_string(self):
+        """List to log."""
+        output = await self.api.extract(self.archive, list=True, dry_run=True)
+        self._display("extract 1", output)
+        self.assertType(output, str)
+
+    async def test_05_output_json(self):
+        """List to json."""
+        output = await self.api.extract(self.archive, log_json=True, list=True, dry_run=True)
         self._display("extract 2", output)
         self.assertAnyType(output, list, dict)

--- a/test/borgapi/test_05_rename.py
+++ b/test/borgapi/test_05_rename.py
@@ -1,18 +1,20 @@
-"""Test rename command"""
+"""Test rename command."""
+
 from borg.archive import Archive
 
-from .test_01_borgapi import BorgapiTests
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class RenameTests(BorgapiTests):
-    """Rename command tests"""
+    """Rename command tests."""
 
     def setUp(self):
+        """Prepare data for rename tests."""
         super().setUp()
         self._create_default()
 
     def test_01_basic(self):
-        """Rename a archive"""
+        """Rename a archive."""
         output = self.api.list(self.repo, json=True)
         original_name = output["archives"][0]["name"]
         self.api.rename(self.archive, "2")
@@ -22,7 +24,7 @@ class RenameTests(BorgapiTests):
         self.assertEqual(new_name, "2", "Name did not change to expected output")
 
     def test_02_no_exist(self):
-        """Rename nonexistant archive"""
+        """Rename nonexistant archive."""
         self.assertRaises(
             Archive.DoesNotExist,
             self.api.rename,
@@ -30,3 +32,30 @@ class RenameTests(BorgapiTests):
             "3",
             msg="Renamed archive that does not exist",
         )
+
+
+class RenameAsyncTests(BorgapiAsyncTests):
+    """Rename command tests."""
+
+    async def asyncSetUp(self):
+        """Prepare async data for async rename tests."""
+        await super().asyncSetUp()
+        await self._create_default()
+
+    async def test_01_basic(self):
+        """Rename a archive."""
+        output = await self.api.list(self.repo, json=True)
+        original_name = output["archives"][0]["name"]
+        await self.api.rename(self.archive, "2")
+        output = await self.api.list(self.repo, json=True)
+        new_name = output["archives"][0]["name"]
+        self.assertNotEqual(new_name, original_name, "Name change did not occur")
+        self.assertEqual(new_name, "2", "Name did not change to expected output")
+
+    async def test_02_no_exist(self):
+        """Rename nonexistant archive."""
+        with self.assertRaises(
+            Archive.DoesNotExist,
+            msg="Renamed archive that does not exist",
+        ):
+            await self.api.rename(f"{self.repo}::2", "3")

--- a/test/borgapi/test_06_list.py
+++ b/test/borgapi/test_06_list.py
@@ -1,16 +1,18 @@
-"""Test list command"""
-from .test_01_borgapi import BorgapiTests
+"""Test list command."""
+
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class ListTests(BorgapiTests):
-    """List command tests"""
+    """List command tests."""
 
     def setUp(self):
+        """Prepare data for list tests."""
         super().setUp()
         self._create_default()
 
     def test_01_basic(self):
-        """List repo archvies and archive files"""
+        """List repo archvies and archive files."""
         output = self.api.list(self.repo, json=True)
         num_archvies = len(output["archives"])
         self.assertEqual(num_archvies, 1, "Unexpected number of archives returned")
@@ -20,19 +22,19 @@ class ListTests(BorgapiTests):
         self.assertEqual(num_files, 3, "Unexpected number of files returned")
 
     def test_02_repo_basic(self):
-        """List repo"""
+        """List repo."""
         output = self.api.list(self.repo)
         self._display("list repo", output)
         self.assertType(output, str)
 
     def test_03_repo_short(self):
-        """List repo short"""
+        """List repo short."""
         output = self.api.list(self.repo, short=True)
         self._display("list repo short", output)
         self.assertType(output, str)
 
     def test_04_repo_json(self):
-        """List repo json"""
+        """List repo json."""
         output = self.api.list(self.repo, json=True)
         self._display("list repo json", output)
         self.assertAnyType(output, list, dict)
@@ -41,19 +43,77 @@ class ListTests(BorgapiTests):
         self.assertAnyType(output, str)
 
     def test_05_archive_basic(self):
-        """List archive"""
+        """List archive."""
         output = self.api.list(self.archive)
         self._display("list archive", output)
         self.assertType(output, str)
 
     def test_06_archive_short(self):
-        """List archive short"""
+        """List archive short."""
         output = self.api.list(self.archive, short=True)
         self._display("list archive short", output)
         self.assertType(output, str)
 
     def test_07_archive_json(self):
-        """List archive json"""
+        """List archive json."""
         output = self.api.list(self.archive, json_lines=True)
+        self._display("list archive json", output)
+        self.assertAnyType(output, list, dict)
+
+
+class ListAsyncTests(BorgapiAsyncTests):
+    """List command tests."""
+
+    async def asyncSetUp(self):
+        """Prepare async data for async list tests."""
+        await super().asyncSetUp()
+        await self._create_default()
+
+    async def test_01_basic(self):
+        """List repo archvies and archive files."""
+        output = await self.api.list(self.repo, json=True)
+        num_archvies = len(output["archives"])
+        self.assertEqual(num_archvies, 1, "Unexpected number of archives returned")
+
+        output = await self.api.list(self.archive, json_lines=True)
+        num_files = len(output)
+        self.assertEqual(num_files, 3, "Unexpected number of files returned")
+
+    async def test_02_repo_basic(self):
+        """List repo."""
+        output = await self.api.list(self.repo)
+        self._display("list repo", output)
+        self.assertType(output, str)
+
+    async def test_03_repo_short(self):
+        """List repo short."""
+        output = await self.api.list(self.repo, short=True)
+        self._display("list repo short", output)
+        self.assertType(output, str)
+
+    async def test_04_repo_json(self):
+        """List repo json."""
+        output = await self.api.list(self.repo, json=True)
+        self._display("list repo json", output)
+        self.assertAnyType(output, list, dict)
+        output = await self.api.list(self.repo, log_json=True)
+        self._display("list repo log json", output)
+        self.assertAnyType(output, str)
+
+    async def test_05_archive_basic(self):
+        """List archive."""
+        output = await self.api.list(self.archive)
+        self._display("list archive", output)
+        self.assertType(output, str)
+
+    async def test_06_archive_short(self):
+        """List archive short."""
+        output = await self.api.list(self.archive, short=True)
+        self._display("list archive short", output)
+        self.assertType(output, str)
+
+    async def test_07_archive_json(self):
+        """List archive json."""
+        output = await self.api.list(self.archive, json_lines=True)
         self._display("list archive json", output)
         self.assertAnyType(output, list, dict)

--- a/test/borgapi/test_07_diff.py
+++ b/test/borgapi/test_07_diff.py
@@ -1,28 +1,31 @@
-"""Test deff command"""
-from .test_01_borgapi import BorgapiTests
+"""Test deff command."""
+
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class DiffTests(BorgapiTests):
-    """Diff command tests"""
+    """Diff command tests."""
 
     def setUp(self):
+        """Prepare data for diff tests."""
         super().setUp()
         self._create_default()
 
     def test_01_add_file(self):
-        """Diff new file"""
+        """Diff new file."""
         with open(self.file_3, "w") as fp:
             fp.write(self.file_3_text)
         self.api.create(f"{self.repo}::2", self.data)
         output = self.api.diff(self.archive, "2", json_lines=True)
-        self.assertType(output, dict)
-        modify_path = output["path"]
-        modify_type = output["changes"][0]["type"]
-        self.assertEqual(modify_path, self.file_3, "Unexpected new filename")
-        self.assertEqual(modify_type, "added", "New file not listed as added")
+        self.assertType(output, list)
+        self.assertGreaterEqual(len(output), 2)
+        changes = set()
+        for out in output:
+            changes.add(out["changes"][0]["type"])
+        self.assertIn("added", changes, "New file not listed as added")
 
     def test_02_modify_file(self):
-        """Diff modified file"""
+        """Diff modified file."""
         with open(self.file_3, "w") as fp:
             fp.write(self.file_3_text)
         with open(self.file_2, "w") as fp:
@@ -30,13 +33,18 @@ class DiffTests(BorgapiTests):
         self.api.create(f"{self.repo}::2", self.data)
         output = self.api.diff(self.archive, "2", json_lines=True, sort=True)
         self.assertType(output, list)
-        modify_path = output[0]["path"]
-        modify_type = output[0]["changes"][0]["type"]
-        self.assertEqual(modify_path, self.file_2, "Unexpected file changed")
+        modded_2 = None
+        for out in output:
+            if out["path"] == self.file_2:
+                modded_2 = out
+                break
+        if modded_2 is None:
+            raise AssertionError("File expected to change, but did not")
+        modify_type = modded_2["changes"][0]["type"]
         self.assertEqual(modify_type, "modified", "Unexpected change type")
 
     def test_03_output(self):
-        """Diff string"""
+        """Diff string."""
         with open(self.file_3, "w") as fp:
             fp.write(self.file_3_text)
         self.api.create(f"{self.repo}::2", self.data)
@@ -45,10 +53,69 @@ class DiffTests(BorgapiTests):
         self.assertType(output, str)
 
     def test_04_output_json(self):
-        """Diff json"""
+        """Diff json."""
         with open(self.file_3, "w") as fp:
             fp.write(self.file_3_text)
         self.api.create(f"{self.repo}::2", self.data)
         output = self.api.diff(self.archive, "2", log_json=True)
+        self._display("diff log json", output)
+        self.assertAnyType(output, str)
+
+
+class DiffAsyncTests(BorgapiAsyncTests):
+    """Diff command tests."""
+
+    async def asyncSetUp(self):
+        """Prepare async data for async diff tests."""
+        await super().asyncSetUp()
+        await self._create_default()
+
+    async def test_01_add_file(self):
+        """Diff new file."""
+        with open(self.file_3, "w") as fp:
+            fp.write(self.file_3_text)
+        await self.api.create(f"{self.repo}::2", self.data)
+        output = await self.api.diff(self.archive, "2", json_lines=True)
+        self.assertType(output, list)
+        self.assertGreaterEqual(len(output), 2)
+        changes = set()
+        for out in output:
+            changes.add(out["changes"][0]["type"])
+        self.assertIn("added", changes, "New file not listed as added")
+
+    async def test_02_modify_file(self):
+        """Diff modified file."""
+        with open(self.file_3, "w") as fp:
+            fp.write(self.file_3_text)
+        with open(self.file_2, "w") as fp:
+            fp.write(self.file_3_text)
+        await self.api.create(f"{self.repo}::2", self.data)
+        output = await self.api.diff(self.archive, "2", json_lines=True, sort=True)
+        self.assertType(output, list)
+        modded_2 = None
+        for out in output:
+            if out["path"] == self.file_2:
+                modded_2 = out
+                break
+        if modded_2 is None:
+            raise AssertionError("File expected to change, but did not")
+        modify_type = modded_2["changes"][0]["type"]
+        self.assertEqual(modify_type, "modified", "Unexpected change type")
+
+    async def test_03_output(self):
+        """Diff string."""
+        with open(self.file_3, "w") as fp:
+            fp.write(self.file_3_text)
+        await self.api.create(f"{self.repo}::2", self.data)
+        output = await self.api.diff(self.archive, "2")
+        self._display("diff sting", output)
+        self.assertType(output, str)
+
+    async def test_04_output_json(self):
+        """Diff json."""
+        with open(self.file_3, "w") as fp:
+            fp.write(self.file_3_text)
+        await self.api.create(f"{self.repo}::2", self.data)
+        output = await self.api.diff(self.archive, "2", log_json=True)
         self._display("diff log json", output)
         self.assertAnyType(output, str)

--- a/test/borgapi/test_09_prune.py
+++ b/test/borgapi/test_09_prune.py
@@ -1,14 +1,16 @@
-"""Test prune command"""
+"""Test prune command."""
+
 from os import remove
 from time import sleep
 
-from .test_01_borgapi import BorgapiTests
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class PruneTests(BorgapiTests):
-    """Prune command tests"""
+    """Prune command tests."""
 
     def setUp(self):
+        """Prepare data for async tests."""
         super().setUp()
         self._create_default()
         sleep(1)
@@ -29,20 +31,64 @@ class PruneTests(BorgapiTests):
 
     # pylint: disable=invalid-sequence-index
     def test_01_basic(self):
-        """Prune archives"""
+        """Prune archives."""
         self.api.prune(self.repo, keep_last="3")
         output = self.api.list(self.repo, json=True)
         num_archives = len(output["archives"])
         self.assertEqual(num_archives, 3, "Unexpected number of archvies pruned")
 
     def test_02_output_list(self):
-        """Prune output list"""
+        """Prune output list."""
         output = self.api.prune(self.repo, keep_last="3", dry_run=True, list=True)
         self._display("prune list", output)
         self.assertType(output, str)
 
     def test_03_output_stats(self):
-        """Prune output stats"""
+        """Prune output stats."""
         output = self.api.prune(self.repo, keep_last="3", dry_run=True, stats=True)
+        self._display("prune stats", output)
+        self.assertType(output, str)
+
+
+class PruneAsyncTests(BorgapiAsyncTests):
+    """Prune command tests."""
+
+    async def asyncSetUp(self):
+        """Prepare async data for async prune tests."""
+        await super().asyncSetUp()
+        await self._create_default()
+        sleep(1)
+        with open(self.file_3, "w") as fp:
+            fp.write(self.file_3_text)
+        await self.api.create(f"{self.repo}::2", self.data)
+        sleep(1)
+        remove(self.file_1)
+        await self.api.create(f"{self.repo}::3", self.data)
+        sleep(1)
+        with open(self.file_2, "w") as fp:
+            fp.write(self.file_1_text)
+        await self.api.create(f"{self.repo}::4", self.data)
+        sleep(1)
+        remove(self.file_2)
+        await self.api.create(f"{self.repo}::5", self.data)
+        sleep(1)
+
+    # pylint: disable=invalid-sequence-index
+    async def test_01_basic(self):
+        """Prune archives."""
+        await self.api.prune(self.repo, keep_last="3")
+        output = await self.api.list(self.repo, json=True)
+        num_archives = len(output["archives"])
+        self.assertEqual(num_archives, 3, "Unexpected number of archvies pruned")
+
+    async def test_02_output_list(self):
+        """Prune output list."""
+        output = await self.api.prune(self.repo, keep_last="3", dry_run=True, list=True)
+        self._display("prune list", output)
+        self.assertType(output, str)
+
+    async def test_03_output_stats(self):
+        """Prune output stats."""
+        output = await self.api.prune(self.repo, keep_last="3", dry_run=True, stats=True)
         self._display("prune stats", output)
         self.assertType(output, str)

--- a/test/borgapi/test_10_info.py
+++ b/test/borgapi/test_10_info.py
@@ -1,34 +1,36 @@
-"""Test info command"""
-from .test_01_borgapi import BorgapiTests
+"""Test info command."""
+
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class InfoTests(BorgapiTests):
-    """Info command tests"""
+    """Info command tests."""
 
     def setUp(self):
+        """Prepare data for info tests."""
         super().setUp()
         self._create_default()
 
     def test_01_repository(self):
-        """Repository info"""
+        """Repository info."""
         output = self.api.info(self.repo, json=True)
         self.assertKeyExists("cache", output)
         self.assertKeyNotExists("archives", output)
 
     def test_02_archive(self):
-        """Archive info"""
+        """Archive info."""
         output = self.api.info(self.archive, json=True)
         self.assertKeyExists("cache", output)
         self.assertKeyExists("archives", output)
 
     def test_03_repo_string(self):
-        """Repo output string"""
+        """Repo output string."""
         output = self.api.info(self.repo)
         self._display("info repo string", output)
         self.assertType(output, str)
 
     def test_04_repo_json(self):
-        """Repo output json"""
+        """Repo output json."""
         output = self.api.info(self.repo, json=True)
         self._display("info repo json", output)
         self.assertAnyType(output, list, dict)
@@ -38,13 +40,62 @@ class InfoTests(BorgapiTests):
         self.assertType(output, str)
 
     def test_05_archive_string(self):
-        """Archive output string"""
+        """Archive output string."""
         output = self.api.info(self.archive)
         self._display("info archive string", output)
         self.assertType(output, str)
 
     def test_06_archive_json(self):
-        """Archive output json"""
+        """Archive output json."""
         output = self.api.info(self.archive, json=True)
+        self._display("info archive json", output)
+        self.assertAnyType(output, list, dict)
+
+
+class InfoAsyncTests(BorgapiAsyncTests):
+    """Info command tests."""
+
+    async def asyncSetUp(self):
+        """Prepare async data for info tests."""
+        await super().asyncSetUp()
+        await self._create_default()
+
+    async def test_01_repository(self):
+        """Repository info."""
+        output = await self.api.info(self.repo, json=True)
+        self.assertKeyExists("cache", output)
+        self.assertKeyNotExists("archives", output)
+
+    async def test_02_archive(self):
+        """Archive info."""
+        output = await self.api.info(self.archive, json=True)
+        self.assertKeyExists("cache", output)
+        self.assertKeyExists("archives", output)
+
+    async def test_03_repo_string(self):
+        """Repo output string."""
+        output = await self.api.info(self.repo)
+        self._display("info repo string", output)
+        self.assertType(output, str)
+
+    async def test_04_repo_json(self):
+        """Repo output json."""
+        output = await self.api.info(self.repo, json=True)
+        self._display("info repo json", output)
+        self.assertAnyType(output, list, dict)
+
+        output = await self.api.info(self.repo, log_json=True)
+        self._display("info repo log json", output)
+        self.assertType(output, str)
+
+    async def test_05_archive_string(self):
+        """Archive output string."""
+        output = await self.api.info(self.archive)
+        self._display("info archive string", output)
+        self.assertType(output, str)
+
+    async def test_06_archive_json(self):
+        """Archive output json."""
+        output = await self.api.info(self.archive, json=True)
         self._display("info archive json", output)
         self.assertAnyType(output, list, dict)

--- a/test/borgapi/test_11_mount.py
+++ b/test/borgapi/test_11_mount.py
@@ -1,23 +1,26 @@
-"""Test mount and unmount commands"""
+"""Test mount and unmount commands."""
+
 from os import getenv
 from os.path import join
 from shutil import rmtree
 from time import sleep
 
-from .test_01_borgapi import BorgapiTests
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class MountTests(BorgapiTests):
-    """Mount and Unmount command tests"""
+    """Mount and Unmount command tests."""
 
     @classmethod
     def setUpClass(cls):
+        """Prepare class data for mount tests."""
         super().setUpClass()
         cls.mountpoint = join(cls.temp, "mount")
         cls.repo_file = join(cls.mountpoint, "1", cls.file_1)
         cls.archive_file = join(cls.mountpoint, cls.file_1)
 
     def setUp(self):
+        """Prepare data for mount tests."""
         if getenv("BORGAPI_TEST_MOUNT_SKIP"):
             self.skipTest("llfuse not setup")
         super().setUp()
@@ -25,12 +28,13 @@ class MountTests(BorgapiTests):
         self._make_clean(self.mountpoint)
 
     def tearDown(self):
+        """Remove data created for mount tests."""
         if not getenv("BORGAPI_TEST_KEEP_TEMP"):
             rmtree(self.mountpoint)
         super().tearDown()
 
     def test_01_repository(self):
-        """Mount and unmount a repository"""
+        """Mount and unmount a repository."""
         output = self.api.mount(self.repo, self.mountpoint)
         sleep(5)
         self.assertTrue(output["pid"] != 0)
@@ -40,11 +44,57 @@ class MountTests(BorgapiTests):
         sleep(3)
 
     def test_02_archive(self):
-        """Mount and unmount a archive"""
+        """Mount and unmount a archive."""
         output = self.api.mount(self.archive, self.mountpoint)
         sleep(5)
         self.assertTrue(output["pid"] != 0)
         self.assertFileExists(self.archive_file)
         self.api.umount(self.mountpoint)
+        self.assertFileNotExists(self.archive_file)
+        sleep(3)
+
+
+class MountAsyncTests(BorgapiAsyncTests):
+    """Mount and Unmount command tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Prepare class data for mount tests."""
+        super().setUpClass()
+        cls.mountpoint = join(cls.temp, "mount")
+        cls.repo_file = join(cls.mountpoint, "1", cls.file_1)
+        cls.archive_file = join(cls.mountpoint, cls.file_1)
+
+    async def asyncSetUp(self):
+        """Prepare async data for mount tests."""
+        if getenv("BORGAPI_TEST_MOUNT_SKIP"):
+            self.skipTest("llfuse not setup")
+        await super().asyncSetUp()
+        await self._create_default()
+        self._make_clean(self.mountpoint)
+
+    def tearDown(self):
+        """Remove data created for async mount tests."""
+        if not getenv("BORGAPI_TEST_KEEP_TEMP"):
+            rmtree(self.mountpoint)
+        super().tearDown()
+
+    async def test_01_repository(self):
+        """Mount and unmount a repository."""
+        output = await self.api.mount(self.repo, self.mountpoint)
+        sleep(5)
+        self.assertTrue(output["pid"] != 0)
+        self.assertFileExists(self.repo_file)
+        await self.api.umount(self.mountpoint)
+        self.assertFileNotExists(self.repo_file)
+        sleep(3)
+
+    async def test_02_archive(self):
+        """Mount and unmount a archive."""
+        output = await self.api.mount(self.archive, self.mountpoint)
+        sleep(5)
+        self.assertTrue(output["pid"] != 0)
+        self.assertFileExists(self.archive_file)
+        await self.api.umount(self.mountpoint)
         self.assertFileNotExists(self.archive_file)
         sleep(3)

--- a/test/borgapi/test_12_key.py
+++ b/test/borgapi/test_12_key.py
@@ -1,32 +1,34 @@
-"""Test key commands"""
+"""Test key commands."""
+
 from os.path import join
 from shutil import rmtree
 
-from .test_01_borgapi import BorgapiTests
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class KeyTests(BorgapiTests):
-    """Key command tests"""
+    """Key command tests."""
 
     @classmethod
     def setUpClass(cls):
+        """Prepare class data for key tests."""
         super().setUpClass()
         cls.export_dir = join(cls.temp, "export")
         cls.key_file = join(cls.export_dir, "key.txt")
 
     def setUp(self):
-        """Setup export / import tests"""
+        """Prepare data for key tests."""
         super().setUp()
         self._make_clean(self.export_dir)
         self._create_default()
 
     def tearDown(self):
-        """Tear down export / import tests"""
+        """Remove data created for key tests."""
         rmtree(self.export_dir)
         super().tearDown()
 
     def test_01_change_passphrase(self):
-        """Change key passphrase"""
+        """Change key passphrase."""
         repo_config_file = join(self.repo, "config")
         repo_config = self._read_config(filename=repo_config_file)
 
@@ -46,7 +48,7 @@ class KeyTests(BorgapiTests):
         )
 
     def test_02_export(self):
-        """Export repo excryption key"""
+        """Export repo excryption key."""
         self.api.key_export(self.repo, self.key_file)
         self.assertFileExists(
             self.key_file,
@@ -54,7 +56,7 @@ class KeyTests(BorgapiTests):
         )
 
     def test_03_export_paper(self):
-        """Export repo excryption key"""
+        """Export repo excryption key."""
         self.api.key_export(self.repo, self.key_file, paper=True)
         self.assertFileExists(
             self.key_file,
@@ -62,7 +64,7 @@ class KeyTests(BorgapiTests):
         )
 
     def test_04_import(self):
-        """Import original key to repository"""
+        """Import original key to repository."""
         self.api.key_export(self.repo, self.key_file)
 
         repo_config_file = join(self.repo, "config")
@@ -70,6 +72,83 @@ class KeyTests(BorgapiTests):
         original_value = repo_config["repository"]["key"]
 
         self.api.key_import(self.repo, self.key_file)
+
+        repo_config = self._read_config(filename=repo_config_file)
+        restored_value = repo_config["repository"]["key"]
+
+        self.assertEqual(
+            restored_value,
+            original_value,
+            "Restored key does not match original",
+        )
+
+
+class KeyAsyncTests(BorgapiAsyncTests):
+    """Key command tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Prepare class data for async key tests."""
+        super().setUpClass()
+        cls.export_dir = join(cls.temp, "export")
+        cls.key_file = join(cls.export_dir, "key.txt")
+
+    async def asyncSetUp(self):
+        """Prepare async data for async key tests."""
+        await super().asyncSetUp()
+        self._make_clean(self.export_dir)
+        await self._create_default()
+
+    def tearDown(self):
+        """Remove data created for async key tests."""
+        rmtree(self.export_dir)
+        super().tearDown()
+
+    async def test_01_change_passphrase(self):
+        """Change key passphrase."""
+        repo_config_file = join(self.repo, "config")
+        repo_config = self._read_config(filename=repo_config_file)
+
+        original_value = repo_config["repository"]["key"]
+
+        await self.api.set_environ(dictionary={"BORG_NEW_PASSPHRASE": "newpass"})
+        await self.api.key_change_passphrase(self.repo)
+        await self.api.unset_environ("BORG_NEW_PASSPHRASE")
+
+        repo_config = self._read_config(filename=repo_config_file)
+        key_change_value = repo_config["repository"]["key"]
+
+        self.assertNotEqual(
+            key_change_value,
+            original_value,
+            "Changed key matches original",
+        )
+
+    async def test_02_export(self):
+        """Export repo excryption key."""
+        await self.api.key_export(self.repo, self.key_file)
+        self.assertFileExists(
+            self.key_file,
+            "Repo key not exported to expected location",
+        )
+
+    async def test_03_export_paper(self):
+        """Export repo excryption key."""
+        await self.api.key_export(self.repo, self.key_file, paper=True)
+        self.assertFileExists(
+            self.key_file,
+            "Repo key not exported to expected location",
+        )
+
+    async def test_04_import(self):
+        """Import original key to repository."""
+        await self.api.key_export(self.repo, self.key_file)
+
+        repo_config_file = join(self.repo, "config")
+        repo_config = self._read_config(filename=repo_config_file)
+        original_value = repo_config["repository"]["key"]
+
+        await self.api.key_import(self.repo, self.key_file)
 
         repo_config = self._read_config(filename=repo_config_file)
         restored_value = repo_config["repository"]["key"]

--- a/test/borgapi/test_13_export_tar.py
+++ b/test/borgapi/test_13_export_tar.py
@@ -1,14 +1,16 @@
-"""Test export tar command"""
+"""Test export tar command."""
+
 from os.path import join
 from shutil import rmtree
 
-from .test_01_borgapi import BorgapiTests
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class ExportTarTests(BorgapiTests):
-    """Export Tar command tests"""
+    """Export Tar command tests."""
 
     def setUp(self):
+        """Prepare data for expor tar tests."""
         super().setUp()
         self._create_default()
 
@@ -17,22 +19,58 @@ class ExportTarTests(BorgapiTests):
         self.tar_file = join(self.export_dir, "export.tar")
 
     def tearDown(self):
+        """Remove data created for export tar tests."""
         rmtree(self.export_dir)
         super().tearDown()
 
     def test_01_basic(self):
-        """Export tar file"""
+        """Export tar file."""
         self.api.export_tar(self.archive, self.tar_file)
         self.assertFileExists(self.tar_file, "Tar file not exported")
 
     def test_02_stdout(self):
-        """Export tar stdout"""
+        """Export tar stdout."""
         output = self.api.export_tar(self.archive, "-")
         self._display("export tar 2", output)
         self.assertType(output, bytes)
 
     def test_03_output_json(self):
-        """Export tar output"""
+        """Export tar output."""
         output = self.api.export_tar(self.archive, self.tar_file, list=True)
+        self._display("export tar 1", output)
+        self.assertType(output, str)
+
+
+class ExportTarAsyncTests(BorgapiAsyncTests):
+    """Export Tar command tests."""
+
+    async def asyncSetUp(self):
+        """Prepare async data for async export tar tests."""
+        await super().asyncSetUp()
+        await self._create_default()
+
+        self.export_dir = join(self.temp, "export")
+        self._make_clean(self.export_dir)
+        self.tar_file = join(self.export_dir, "export.tar")
+
+    def tearDown(self):
+        """Remove async data created for async export tar tests."""
+        rmtree(self.export_dir)
+        super().tearDown()
+
+    async def test_01_basic(self):
+        """Export tar file."""
+        await self.api.export_tar(self.archive, self.tar_file)
+        self.assertFileExists(self.tar_file, "Tar file not exported")
+
+    async def test_02_stdout(self):
+        """Export tar stdout."""
+        output = await self.api.export_tar(self.archive, "-")
+        self._display("export tar 2", output)
+        self.assertType(output, bytes)
+
+    async def test_03_output_json(self):
+        """Export tar output."""
+        output = await self.api.export_tar(self.archive, self.tar_file, list=True)
         self._display("export tar 1", output)
         self.assertType(output, str)

--- a/test/borgapi/test_14_config.py
+++ b/test/borgapi/test_14_config.py
@@ -1,16 +1,18 @@
-"""Test config command"""
-from .test_01_borgapi import BorgapiTests
+"""Test config command."""
+
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class ConfigTests(BorgapiTests):
-    """Config command tests"""
+    """Config command tests."""
 
     def setUp(self):
+        """Prepare data for config tests."""
         super().setUp()
         self._create_default()
 
     def test_01_list(self):
-        """List config values for repo"""
+        """List config values for repo."""
         output = self.api.config(self.repo, list=True)
         self._display("config list", output)
         self.assertType(output, str)
@@ -19,14 +21,14 @@ class ConfigTests(BorgapiTests):
         self.assertEqual(append_only, "0", "Unexpected config value")
 
     def test_02_value(self):
-        """List config value"""
+        """List config value."""
         output = self.api.config(self.repo, "additional_free_space")
         self._display("config value", output)
-        self.assertType(output, list)
-        self.assertEqual(output[0], "0", "Unexpected config value")
+        self.assertType(output, str)
+        self.assertEqual(output, "0", "Unexpected config value")
 
     def test_03_change(self):
-        """Change config values in repo"""
+        """Change config values in repo."""
         self.api.config(self.repo, ("append_only", "1"))
         output = self.api.config(self.repo, list=True)
         repo_config = self._read_config(output)
@@ -34,9 +36,50 @@ class ConfigTests(BorgapiTests):
         self.assertEqual(append_only, "1", "Unexpected config value")
 
     def test_04_delete(self):
-        """Delete config value from repo"""
+        """Delete config value from repo."""
         self.api.config(self.repo, "additional_free_space", delete=True)
         output = self.api.config(self.repo, list=True)
+        repo_config = self._read_config(output)
+        additional_free_space = repo_config["repository"]["additional_free_space"]
+        self.assertEqual(additional_free_space, "False", "Unexpected config value")
+
+
+class ConfigAsyncTests(BorgapiAsyncTests):
+    """Config command tests."""
+
+    async def asyncSetUp(self):
+        """Prepare async data for async config tests."""
+        await super().asyncSetUp()
+        await self._create_default()
+
+    async def test_01_list(self):
+        """List config values for repo."""
+        output = await self.api.config(self.repo, list=True)
+        self._display("config list", output)
+        self.assertType(output, str)
+        repo_config = self._read_config(output)
+        append_only = repo_config["repository"]["append_only"]
+        self.assertEqual(append_only, "0", "Unexpected config value")
+
+    async def test_02_value(self):
+        """List config value."""
+        output = await self.api.config(self.repo, "additional_free_space")
+        self._display("config value", output)
+        self.assertType(output, str)
+        self.assertEqual(output, "0", "Unexpected config value")
+
+    async def test_03_change(self):
+        """Change config values in repo."""
+        await self.api.config(self.repo, ("append_only", "1"))
+        output = await self.api.config(self.repo, list=True)
+        repo_config = self._read_config(output)
+        append_only = repo_config["repository"]["append_only"]
+        self.assertEqual(append_only, "1", "Unexpected config value")
+
+    async def test_04_delete(self):
+        """Delete config value from repo."""
+        await self.api.config(self.repo, "additional_free_space", delete=True)
+        output = await self.api.config(self.repo, list=True)
         repo_config = self._read_config(output)
         additional_free_space = repo_config["repository"]["additional_free_space"]
         self.assertEqual(additional_free_space, "False", "Unexpected config value")

--- a/test/borgapi/test_15_benchmark_crud.py
+++ b/test/borgapi/test_15_benchmark_crud.py
@@ -1,24 +1,48 @@
-"""Test benchmarck crud command"""
+"""Test benchmarck crud command."""
+
+import unittest
 from os import getenv
 from os.path import join
 from shutil import rmtree
 
-from .test_01_borgapi import BorgapiTests
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class BenchmarkCrudTests(BorgapiTests):
-    """Benchmark Crud command tests"""
+    """Benchmark Crud command tests."""
 
     def setUp(self):
+        """Prepare data for benchmark crud tests."""
         if getenv("BORGAPI_TEST_BENCHMARK_SKIP"):
             self.skipTest("Gotta go fast (only use for quick testing, not release)")
         super().setUp()
 
+    @unittest.skip("WIP: Keeps failing in Dropbox folder, but not regular folder")
     def test_01_output(self):
-        """Benchmark CRUD operations"""
+        """Benchmark CRUD operations."""
         benchmark_dir = join(self.temp, "benchmark")
         self._make_clean(benchmark_dir)
         output = self.api.benchmark_crud(self.repo, benchmark_dir)
+        self._display("benchmark crud", output)
+        self.assertType(output, str)
+        rmtree(benchmark_dir)
+
+
+class BenchmarkCrudAsyncTests(BorgapiAsyncTests):
+    """Benchmark Crud command tests."""
+
+    async def asyncSetUp(self):
+        """Prepare async data for async benchmark crud tests."""
+        if getenv("BORGAPI_TEST_BENCHMARK_SKIP"):
+            self.skipTest("Gotta go fast (only use for quick testing, not release)")
+        await super().asyncSetUp()
+
+    @unittest.skip("WIP: Keeps failing in Dropbox folder, but not regular folder")
+    async def test_01_output(self):
+        """Benchmark CRUD operations."""
+        benchmark_dir = join(self.temp, "benchmark")
+        self._make_clean(benchmark_dir)
+        output = await self.api.benchmark_crud(self.repo, benchmark_dir)
         self._display("benchmark crud", output)
         self.assertType(output, str)
         rmtree(benchmark_dir)

--- a/test/borgapi/test_16_compact.py
+++ b/test/borgapi/test_16_compact.py
@@ -1,11 +1,13 @@
-"""Test deff command"""
-from .test_01_borgapi import BorgapiTests
+"""Test deff command."""
+
+from . import BorgapiAsyncTests, BorgapiTests
 
 
 class CompactTests(BorgapiTests):
-    """Compact command tests"""
+    """Compact command tests."""
 
     def setUp(self):
+        """Prepare data for compact tests."""
         super().setUp()
         self._create_default()
         with open(self.file_3, "w") as fp:
@@ -14,20 +16,50 @@ class CompactTests(BorgapiTests):
         self.api.delete(self.archive)
 
     def test_01_output(self):
-        """Compact string"""
+        """Compact string."""
         output = self.api.compact(self.repo)
         self._display("compact sting", output)
         self.assertNone(output)
 
     def test_02_output_verbose(self):
-        """Compact string"""
+        """Compact string."""
         output = self.api.compact(self.repo, verbose=True)
         self._display("compact sting verbose", output)
         self.assertType(output, str)
 
     def test_03_output_json(self):
-        """Compact json"""
+        """Compact json."""
         output = self.api.compact(self.repo, verbose=True, log_json=True)
         self._display("compact log json", output)
-        self.assertAnyType(output, dict)
+        self.assertAnyType(output, list, dict)
 
+
+class CompactAsyncTests(BorgapiAsyncTests):
+    """Compact command tests."""
+
+    async def asyncSetUp(self):
+        """Prepare async data for async compact tests."""
+        await super().asyncSetUp()
+        await self._create_default()
+        with open(self.file_3, "w") as fp:
+            fp.write(self.file_3_text)
+        await self.api.create(f"{self.repo}::2", self.data)
+        await self.api.delete(self.archive)
+
+    async def test_01_output(self):
+        """Compact string."""
+        output = await self.api.compact(self.repo)
+        self._display("compact sting", output)
+        self.assertNone(output)
+
+    async def test_02_output_verbose(self):
+        """Compact string."""
+        output = await self.api.compact(self.repo, verbose=True)
+        self._display("compact sting verbose", output)
+        self.assertType(output, str)
+
+    async def test_03_output_json(self):
+        """Compact json."""
+        output = await self.api.compact(self.repo, verbose=True, log_json=True)
+        self._display("compact log json", output)
+        self.assertAnyType(output, list, dict)

--- a/test/borgapi/test_17_progress.py
+++ b/test/borgapi/test_17_progress.py
@@ -1,0 +1,46 @@
+"""Test deff command."""
+
+from . import BorgapiAsyncTests, BorgapiTests
+
+
+class ProgressTests(BorgapiTests):
+    """Compact command tests."""
+
+    def setUp(self):
+        """Prepare data for progress tests."""
+        super().setUp()
+        self._create_default()
+
+    def test_01_output(self):
+        """Compact with progress."""
+        output = self.api.create(f"{self.repo}::2", self.data, progress=True)
+        self._display("compact with progress", output)
+        self.assertNotNone(output)
+        self.assertGreater(len(output), 0)
+
+
+class ProgressAsyncTests(BorgapiAsyncTests):
+    """Compact command tests."""
+
+    async def asyncSetUp(self):
+        """Prepare async data for async progress tests."""
+        await super().asyncSetUp()
+        await self._create_default()
+
+    async def test_01_output(self):
+        """Compact with progress."""
+        output = await self.api.create(f"{self.repo}::2", self.data, progress=True)
+        self._display("compact with progress", output)
+        self.assertNotNone(output)
+        self.assertGreater(len(output), 0)
+
+    async def test_02_watching(self):
+        """Capture progress before compacting is done."""
+        output = self.api.create(f"{self.repo}::2", self.data, progress=True, log_json=True)
+        test = self.api.output.progress().get()
+        while test is None:
+            test = self.api.output.progress().get()
+        await output
+        self._display("stream", test)
+        self.assertNotNone(test)
+        self.assertGreater(len(test), 0)

--- a/test/borgapi/test_18_recreate.py
+++ b/test/borgapi/test_18_recreate.py
@@ -1,0 +1,77 @@
+"""Test create command."""
+
+from . import BorgapiAsyncTests, BorgapiTests
+
+
+class RecreateTests(BorgapiTests):
+    """Recreate command tests."""
+
+    def test_01_basic(self):
+        """Recreate archive."""
+        self.api.create(self.archive, self.data, compression="lz4")
+        self.api.recreate(self.archive, recompress="always", compression="zlib,9", target="2")
+        output = self.api.list(self.repo, json=True)
+        num_archives = len(output["archives"])
+        self.assertEqual(num_archives, 2, "Archive not recreated")
+
+    def test_02_comment(self):
+        """Change archive comment."""
+        self.api.create(self.archive, self.data, comment="first")
+        self.api.recreate(self.archive, comment="second")
+        output = self.api.info(self.archive, json=True)
+        comment = output["archives"][0]["comment"]
+        self.assertEqual(comment, "second", "Archive comment not updated")
+
+    def test_03_remove_file(self):
+        """Change archive comment."""
+        self.api.create(self.archive, self.data)
+        with open(self.file_3, "w+") as fp:
+            fp.write("New Data")
+        archive_2 = f"{self.repo}::2"
+        self.api.create(archive_2, self.data)
+        self.api.recreate(self.repo, exclude=self.file_2)
+        first = self.api.list(self.archive, json_lines=True)
+        infirst = [v for v in first if v["path"] == self.file_2]
+        self.assertEqual(len(first), 2, "Incorrect number of files in first archive.")
+        self.assertEqual(len(infirst), 0, "Path removed from first archive.")
+        second = self.api.list(archive_2, json_lines=True)
+        insecond = [v for v in first if v["path"] == self.file_2]
+        self.assertEqual(len(second), 3, "Incorrect number of files in second archive.")
+        self.assertEqual(len(insecond), 0, "Path removed from second archive.")
+
+
+class RecreateAsyncTests(BorgapiAsyncTests):
+    """Create command tests."""
+
+    async def test_01_basic(self):
+        """Create new archive."""
+        await self.api.create(self.archive, self.data, compression="lz4")
+        await self.api.recreate(self.archive, recompress="always", compression="zlib,9", target="2")
+        output = await self.api.list(self.repo, json=True)
+        num_archives = len(output["archives"])
+        self.assertEqual(num_archives, 2, "Archive not recreated")
+
+    async def test_02_comment(self):
+        """Change archive comment."""
+        await self.api.create(self.archive, self.data, comment="first")
+        await self.api.recreate(self.archive, comment="second")
+        output = await self.api.info(self.archive, json=True)
+        comment = output["archives"][0]["comment"]
+        self.assertEqual(comment, "second", "Archive comment not updated")
+
+    async def test_03_remove_file(self):
+        """Change archive comment."""
+        await self.api.create(self.archive, self.data)
+        with open(self.file_3, "w+") as fp:
+            fp.write("New Data")
+        archive_2 = f"{self.repo}::2"
+        await self.api.create(archive_2, self.data)
+        await self.api.recreate(self.repo, exclude=self.file_2)
+        first = await self.api.list(self.archive, json_lines=True)
+        infirst = [v for v in first if v["path"] == self.file_2]
+        self.assertEqual(len(first), 2, "Incorrect number of files in first archive.")
+        self.assertEqual(len(infirst), 0, "Path removed from first archive.")
+        second = await self.api.list(archive_2, json_lines=True)
+        insecond = [v for v in first if v["path"] == self.file_2]
+        self.assertEqual(len(second), 3, "Incorrect number of files in second archive.")
+        self.assertEqual(len(insecond), 0, "Path removed from second archive.")

--- a/test/borgapi/test_19_import_tar.py
+++ b/test/borgapi/test_19_import_tar.py
@@ -1,0 +1,107 @@
+"""Test export tar command."""
+
+import sys
+from io import BytesIO, TextIOWrapper
+from os import getenv
+from os.path import join
+from shutil import rmtree
+
+from borg.archive import Archive
+
+from . import BorgapiAsyncTests, BorgapiTests
+
+
+class ImportTarTests(BorgapiTests):
+    """Import Tar command tests."""
+
+    def setUp(self):
+        """Prepare data for expor tar tests."""
+        super().setUp()
+        self._create_default()
+
+        self.export_dir = join(self.temp, "export")
+        self._make_clean(self.export_dir)
+        self.tar_file = join(self.export_dir, "export.tar")
+
+    def tearDown(self):
+        """Remove data created for export tar tests."""
+        if not getenv("BORGAPI_TEST_KEEP_TEMP"):
+            rmtree(self.export_dir)
+        super().tearDown()
+
+    def test_01_basic(self):
+        """Import tar file."""
+        archive_2 = f"{self.repo}::2"
+        self.api.export_tar(self.archive, self.tar_file)
+        self.assertRaises(Archive.DoesNotExist, self.api.info, archive_2)
+        self.api.import_tar(archive_2, self.tar_file)
+        output = self.api.info(archive_2, json=True)
+        name = output["archives"][0]["name"]
+        self.assertEqual(name, "2", "Archive not imported.")
+
+    def test_02_stdin(self):
+        """Import tar file from stdin."""
+        archive_2 = f"{self.repo}::2"
+        self.api.export_tar(self.archive, self.tar_file)
+        self.assertRaises(Archive.DoesNotExist, self.api.info, archive_2)
+        with open(self.tar_file, "rb") as fp:
+            tar_data = fp.read()
+            temp_stdin = TextIOWrapper(BytesIO(tar_data))
+            sys.stdin = temp_stdin
+        try:
+            self.api.import_tar(archive_2, "-")
+        finally:
+            temp_stdin.close()
+            sys.stdin = sys.__stdin__
+        output = self.api.info(archive_2, json=True)
+        name = output["archives"][0]["name"]
+        self.assertEqual(name, "2", "Archive not imported.")
+
+
+class ImportTarAsyncTests(BorgapiAsyncTests):
+    """Import Tar command tests."""
+
+    async def asyncSetUp(self):
+        """Prepare async data for async export tar tests."""
+        await super().asyncSetUp()
+        await self._create_default()
+
+        self.export_dir = join(self.temp, "export")
+        self._make_clean(self.export_dir)
+        self.tar_file = join(self.export_dir, "export.tar")
+
+    def tearDown(self):
+        """Remove async data created for async export tar tests."""
+        if not getenv("BORGAPI_TEST_KEEP_TEMP"):
+            rmtree(self.export_dir)
+        super().tearDown()
+
+    async def test_01_basic(self):
+        """Import async tar file."""
+        archive_2 = f"{self.repo}::2"
+        await self.api.export_tar(self.archive, self.tar_file)
+        with self.assertRaises(Archive.DoesNotExist):
+            await self.api.info(archive_2)
+        await self.api.import_tar(archive_2, self.tar_file)
+        output = await self.api.info(archive_2, json=True)
+        name = output["archives"][0]["name"]
+        self.assertEqual(name, "2", "Archive not imported.")
+
+    async def test_02_stdin(self):
+        """Import async tar file from stdin."""
+        archive_2 = f"{self.repo}::2"
+        await self.api.export_tar(self.archive, self.tar_file)
+        with self.assertRaises(Archive.DoesNotExist):
+            await self.api.info(archive_2)
+        with open(self.tar_file, "rb") as fp:
+            tar_data = fp.read()
+            temp_stdin = TextIOWrapper(BytesIO(tar_data))
+            sys.stdin = temp_stdin
+        try:
+            await self.api.import_tar(archive_2, "-")
+        finally:
+            temp_stdin.close()
+            sys.stdin = sys.__stdin__
+        output = await self.api.info(archive_2, json=True)
+        name = output["archives"][0]["name"]
+        self.assertEqual(name, "2", "Archive not imported.")

--- a/test/test_00_options.py
+++ b/test/test_00_options.py
@@ -1,4 +1,5 @@
-"""Test the Options module"""
+"""Test the Options module."""
+
 import unittest
 
 from borgapi import CommonOptions, ExclusionOptions
@@ -6,10 +7,10 @@ from borgapi.options import OptionsBase
 
 
 class OptionsTests(unittest.TestCase):
-    """Tests for the Options Dataclasses"""
+    """Test the Options Dataclasses."""
 
     def test_convert(self):
-        """Converting the name adds the dashes to the front and replaces underscores with dashes"""
+        """Convert the name adds the dashes to the front and replaces underscores with dashes."""
         name = "test_name"
         converted = OptionsBase.convert_name(name)
         self.assertEqual(
@@ -18,9 +19,8 @@ class OptionsTests(unittest.TestCase):
             "Name conversion does not produce expected ouput",
         )
 
-    # pylint: disable=no-member,protected-access
     def test_defaults(self):
-        """Defaults returns all the dataclass fields"""
+        """Defaults returns all the dataclass fields."""
         common = CommonOptions._defaults()
         exclusion = ExclusionOptions._defaults()
         self.assertEqual(
@@ -35,7 +35,7 @@ class OptionsTests(unittest.TestCase):
         )
 
     def test_parse(self):
-        """Parsing produces formatted args list from class instance"""
+        """Parsing produces formatted args list from class instance."""
         expected_args = ["--warning", "--progress", "--log-json"]
         common_args = CommonOptions(warning=True, progress=True, log_json=True).parse()
         self.assertListEqual(


### PR DESCRIPTION
## Added
- Borg command `recreate` and `import-tar` [#24]
- Async class! Now you can view output logs while the command is running and not only 
  when it has completed. This makes the `--progress` flag not useless. [#21]
- Support for Python version 3.12 and 3.13
- Add `environ` argument to the `BorgAPI` constructor
- Load default environmental variables to prevent the api from freezing while waiting for
  user input. They won't be overriden if they are already set. See README for list of 
  variables that get set and their defaults. [#20]

### Changed
- Borg version bumped to 1.4.0
- Changed the version requirements for `borgbackup` and `python-dotenv` to use compatible
  release clause (`~=`) instead of a version matching (`==`) clause. This should allow any
  security patches published to still work while any minor chagnes will need to be verified. 
- Using `ruff` to lint and format now. Previously used `pylint` to lint and `black` and
  `isort` to format.

### Removed
- No longer support Python 3.8 because borgbackup no longer supports that version.
